### PR TITLE
Localize cmux tool split command copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `cmux-review` with `/review-v` and `/review-h`, plus bundled `code-review` skill and `/review` / `/review-diff` prompt templates for focused review workflows, including GitHub pull request review via `gh` when given a PR URL.
 - Added `cmux-continue` with `/cmcv` and `/cmch` for split-based task handoff in the current checkout or by creating a git worktree branch with `-c <branch>`.
 - Added `cmux-open` with `/cmo`, `/cmov`, and `/cmoh` to open a new split and run any shell command there.
+- Added optional localized copy for `/cmo`, `/cmov`, and `/cmoh` when a Pi i18n provider is present.
 
 ### Changed
 

--- a/extensions/cmux-open.ts
+++ b/extensions/cmux-open.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { buildShellCommand, openCommandInNewSplit, type SplitDirection } from "./cmux-core.ts";
+import { t } from "./i18n.ts";
 
 async function openToolInSplit(
 	pi: ExtensionAPI,
@@ -22,7 +23,7 @@ function registerOpenCommand(
 		handler: async (args, ctx) => {
 			const command = args.trim();
 			if (!command) {
-				ctx.ui.notify(`Usage: /${name} <command...>`, "warning");
+				ctx.ui.notify(t("open.usage", { name }), "warning");
 				return;
 			}
 
@@ -30,7 +31,7 @@ function registerOpenCommand(
 			if (result.ok) {
 				ctx.ui.notify(successMessage, "info");
 			} else {
-				ctx.ui.notify(`tool split failed: ${result.error}`, "error");
+				ctx.ui.notify(t("open.failed", { error: result.error }), "error");
 			}
 		},
 	});
@@ -41,22 +42,22 @@ export default function cmuxOpenExtension(pi: ExtensionAPI) {
 		pi,
 		"cmo",
 		"right",
-		"Open a new right split and run any shell command there",
-		"Opened a tool split to the right",
+		t("open.right.description"),
+		t("open.success.right"),
 	);
 	registerOpenCommand(
 		pi,
 		"cmov",
 		"right",
-		"Alias for /cmo",
-		"Opened a tool split to the right",
+		t("open.alias.cmo"),
+		t("open.success.right"),
 	);
 
 	registerOpenCommand(
 		pi,
 		"cmoh",
 		"down",
-		"Open a new lower split and run any shell command there",
-		"Opened a tool split below",
+		t("open.down.description"),
+		t("open.success.down"),
 	);
 }

--- a/extensions/cmux-open.ts
+++ b/extensions/cmux-open.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { buildShellCommand, openCommandInNewSplit, type SplitDirection } from "./cmux-core.ts";
-import { t } from "./i18n.ts";
+import { onI18nLocaleChanged, t, type I18nKey } from "./i18n.ts";
 
 async function openToolInSplit(
 	pi: ExtensionAPI,
@@ -15,11 +15,11 @@ function registerOpenCommand(
 	pi: ExtensionAPI,
 	name: string,
 	direction: SplitDirection,
-	description: string,
-	successMessage: string,
+	descriptionKey: I18nKey,
+	successKey: I18nKey,
 ): void {
 	pi.registerCommand(name, {
-		description,
+		description: t(descriptionKey),
 		handler: async (args, ctx) => {
 			const command = args.trim();
 			if (!command) {
@@ -29,7 +29,7 @@ function registerOpenCommand(
 
 			const result = await openToolInSplit(pi, ctx, direction, command);
 			if (result.ok) {
-				ctx.ui.notify(successMessage, "info");
+				ctx.ui.notify(t(successKey), "info");
 			} else {
 				ctx.ui.notify(t("open.failed", { error: result.error }), "error");
 			}
@@ -37,27 +37,34 @@ function registerOpenCommand(
 	});
 }
 
-export default function cmuxOpenExtension(pi: ExtensionAPI) {
+function registerOpenCommands(pi: ExtensionAPI): void {
 	registerOpenCommand(
 		pi,
 		"cmo",
 		"right",
-		t("open.right.description"),
-		t("open.success.right"),
+		"open.right.description",
+		"open.success.right",
 	);
 	registerOpenCommand(
 		pi,
 		"cmov",
 		"right",
-		t("open.alias.cmo"),
-		t("open.success.right"),
+		"open.alias.cmo",
+		"open.success.right",
 	);
 
 	registerOpenCommand(
 		pi,
 		"cmoh",
 		"down",
-		t("open.down.description"),
-		t("open.success.down"),
+		"open.down.description",
+		"open.success.down",
 	);
+}
+
+export default function cmuxOpenExtension(pi: ExtensionAPI) {
+	registerOpenCommands(pi);
+	onI18nLocaleChanged(pi, () => {
+		registerOpenCommands(pi);
+	});
 }

--- a/extensions/i18n.ts
+++ b/extensions/i18n.ts
@@ -1,0 +1,79 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Locale = "es" | "fr" | "pt-BR";
+type Key = keyof typeof fallback;
+type Params = Record<string, string | number>;
+
+const namespace = "pi-cmux";
+
+const fallback = {
+	"open.usage": "Usage: /{name} <command...>",
+	"open.failed": "tool split failed: {error}",
+	"open.right.description": "Open a new right split and run any shell command there",
+	"open.down.description": "Open a new lower split and run any shell command there",
+	"open.alias.cmo": "Alias for /cmo",
+	"open.success.right": "Opened a tool split to the right",
+	"open.success.down": "Opened a tool split below",
+} as const;
+
+const translations: Record<Locale, Partial<Record<Key, string>>> = {
+	es: {
+		"open.usage": "Uso: /{name} <comando...>",
+		"open.failed": "falló la división de herramienta: {error}",
+		"open.right.description": "Abrir una nueva división a la derecha y ejecutar allí cualquier comando de shell",
+		"open.down.description": "Abrir una nueva división inferior y ejecutar allí cualquier comando de shell",
+		"open.alias.cmo": "Alias de /cmo",
+		"open.success.right": "Se abrió una división de herramienta a la derecha",
+		"open.success.down": "Se abrió una división de herramienta abajo",
+	},
+	fr: {
+		"open.usage": "Utilisation : /{name} <commande...>",
+		"open.failed": "échec du split d’outil : {error}",
+		"open.right.description": "Ouvrir un nouveau split à droite et y exécuter n’importe quelle commande shell",
+		"open.down.description": "Ouvrir un nouveau split inférieur et y exécuter n’importe quelle commande shell",
+		"open.alias.cmo": "Alias de /cmo",
+		"open.success.right": "Split d’outil ouvert à droite",
+		"open.success.down": "Split d’outil ouvert en bas",
+	},
+	"pt-BR": {
+		"open.usage": "Uso: /{name} <comando...>",
+		"open.failed": "falha ao abrir divisão de ferramenta: {error}",
+		"open.right.description": "Abrir uma nova divisão à direita e executar qualquer comando de shell nela",
+		"open.down.description": "Abrir uma nova divisão inferior e executar qualquer comando de shell nela",
+		"open.alias.cmo": "Alias para /cmo",
+		"open.success.right": "Divisão de ferramenta aberta à direita",
+		"open.success.down": "Divisão de ferramenta aberta abaixo",
+	},
+};
+
+let currentLocale: string | undefined;
+
+function format(template: string, params: Params = {}): string {
+	return template.replace(/\{(\w+)\}/g, (_match, key) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: Key, params?: Params): string {
+	const locale = currentLocale as Locale | undefined;
+	const template = locale ? translations[locale]?.[key] : undefined;
+	return format(template ?? fallback[key], params);
+}
+
+export function initI18n(pi: ExtensionAPI): void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", {
+		namespace,
+		defaultLocale: "en",
+		fallback,
+		translations,
+	});
+	pi.events?.on?.("pi-core/i18n/localeChanged", (event: unknown) => {
+		currentLocale = event && typeof event === "object" && "locale" in event
+			? String((event as { locale?: unknown }).locale ?? "")
+			: undefined;
+	});
+	pi.events?.emit?.("pi-core/i18n/requestApi", {
+		namespace,
+		onApi(api: { getLocale?: () => string | undefined }) {
+			currentLocale = api.getLocale?.();
+		},
+	});
+}

--- a/extensions/i18n.ts
+++ b/extensions/i18n.ts
@@ -1,10 +1,10 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 type Locale = "es" | "fr" | "pt-BR";
-type Key = keyof typeof fallback;
 type Params = Record<string, string | number>;
 
 const namespace = "pi-cmux";
+const localeChangedEvent = `${namespace}/i18n/localeChanged`;
 
 const fallback = {
 	"open.usage": "Usage: /{name} <command...>",
@@ -16,7 +16,9 @@ const fallback = {
 	"open.success.down": "Opened a tool split below",
 } as const;
 
-const translations: Record<Locale, Partial<Record<Key, string>>> = {
+export type I18nKey = keyof typeof fallback;
+
+const translations: Record<Locale, Partial<Record<I18nKey, string>>> = {
 	es: {
 		"open.usage": "Uso: /{name} <comando...>",
 		"open.failed": "falló la división de herramienta: {error}",
@@ -52,10 +54,39 @@ function format(template: string, params: Params = {}): string {
 	return template.replace(/\{(\w+)\}/g, (_match, key) => String(params[key] ?? `{${key}}`));
 }
 
-export function t(key: Key, params?: Params): string {
-	const locale = currentLocale as Locale | undefined;
+function coerceLocale(value: unknown): string | undefined {
+	if (typeof value !== "string") {
+		return undefined;
+	}
+	const locale = value.trim();
+	return locale.length > 0 ? locale : undefined;
+}
+
+function resolveLocale(locale: string | undefined): Locale | undefined {
+	const normalized = locale?.replace("_", "-");
+	if (normalized === "pt-BR" || normalized === "pt-br") {
+		return "pt-BR";
+	}
+	const baseLocale = normalized?.split("-")[0];
+	return baseLocale === "es" || baseLocale === "fr" ? baseLocale : undefined;
+}
+
+function setCurrentLocale(pi: ExtensionAPI, locale: string | undefined): void {
+	if (currentLocale === locale) {
+		return;
+	}
+	currentLocale = locale;
+	pi.events?.emit?.(localeChangedEvent, { locale: currentLocale });
+}
+
+export function t(key: I18nKey, params?: Params): string {
+	const locale = resolveLocale(currentLocale);
 	const template = locale ? translations[locale]?.[key] : undefined;
 	return format(template ?? fallback[key], params);
+}
+
+export function onI18nLocaleChanged(pi: ExtensionAPI, handler: () => void): void {
+	pi.events?.on?.(localeChangedEvent, handler);
 }
 
 export function initI18n(pi: ExtensionAPI): void {
@@ -66,14 +97,15 @@ export function initI18n(pi: ExtensionAPI): void {
 		translations,
 	});
 	pi.events?.on?.("pi-core/i18n/localeChanged", (event: unknown) => {
-		currentLocale = event && typeof event === "object" && "locale" in event
-			? String((event as { locale?: unknown }).locale ?? "")
+		const locale = event && typeof event === "object" && "locale" in event
+			? coerceLocale((event as { locale?: unknown }).locale)
 			: undefined;
+		setCurrentLocale(pi, locale);
 	});
 	pi.events?.emit?.("pi-core/i18n/requestApi", {
 		namespace,
 		onApi(api: { getLocale?: () => string | undefined }) {
-			currentLocale = api.getLocale?.();
+			setCurrentLocale(pi, coerceLocale(api.getLocale?.()));
 		},
 	});
 }

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -5,8 +5,10 @@ import cmuxZoxideExtension from "./cmux-zoxide.ts";
 import cmuxReviewExtension from "./cmux-review.ts";
 import cmuxContinueExtension from "./cmux-continue.ts";
 import cmuxOpenExtension from "./cmux-open.ts";
+import { initI18n } from "./i18n.ts";
 
 export default function piCmuxExtensionBundle(pi: ExtensionAPI) {
+	initI18n(pi);
 	cmuxNotifyExtension(pi);
 	cmuxSplitExtension(pi);
 	cmuxZoxideExtension(pi);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-cmux",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Pi package with cmux-powered terminal integrations",
   "author": "Javi Molina",
   "license": "MIT",


### PR DESCRIPTION
This keeps pi-cmux English by default, but makes the generic tool-split path optionally localizable.

Why these strings:
- `/cmo` and `/cmoh` run arbitrary shell commands in a new cmux split, so the usage/error/success copy is the point where users decide whether a command actually launched or failed.
- I kept this to the tool-split command path only; no README, prompts, skills, generated files, or package changes.

What changed:
- adds a tiny optional i18n bridge with English fallbacks
- adds es/fr/pt-BR bundles for `/cmo`/`/cmoh` descriptions, usage, failure, and success messages
- preserves current behavior when no i18n provider is present

Validation:
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --allowImportingTsExtensions extensions/index.ts` passed
- `npm pack --dry-run` passed

If useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.