### PR TITLE
feat(notify): include LLM response text in notification body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Made `/cmrv` and `/cmrh` default to reviewing the current git diff when run without arguments.
 - Extended `/cmcv -c` and `/cmch -c` to support `--from <ref>` / `-f <ref>` when creating a new worktree branch.
 - Added `PI_CMUX_NOTIFY_LEVEL=all|medium|low|disabled` so notification verbosity can be configured with one opinionated setting.
+- Added `PI_CMUX_NOTIFY_INCLUDE_RESPONSE=1` to optionally append the final assistant response to non-error notifications.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ All notifications use:
 - subtitle: current run state
 - body: a short summary of what pi just did
 
+Set `PI_CMUX_NOTIFY_INCLUDE_RESPONSE=1` to append up to 500 characters of the final assistant response to non-error notifications. This is disabled by default because assistant responses can contain sensitive text. Response text is only appended for final assistant messages that stopped normally or due to length limits; tool-use, error, and aborted turns are ignored.
+
 Current notification types:
 
 - `Waiting`
@@ -101,6 +103,7 @@ Notification bodies are summarized from the run itself:
 - searches from `grep` and `find`
 - shell activity from `bash`
 - the final agent error, with the first tool failure used as a fallback summary when needed
+- optionally, the final assistant response when `PI_CMUX_NOTIFY_INCLUDE_RESPONSE=1`
 
 ### cmux split commands
 

--- a/extensions/cmux-notify.ts
+++ b/extensions/cmux-notify.ts
@@ -13,6 +13,7 @@ const DEFAULT_THRESHOLD_MS = 15000;
 const DEFAULT_DEBOUNCE_MS = 3000;
 const NOTIFY_TIMEOUT_MS = 5000;
 const DEFAULT_NOTIFY_LEVEL = "all";
+const ASSISTANT_RESPONSE_MAX_LENGTH = 500;
 
 type NotifyLevel = "all" | "medium" | "low" | "disabled";
 
@@ -266,6 +267,29 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 		}
 	});
 
+	const getAssistantResponseText = (messages: readonly unknown[]): string | undefined => {
+		const lastAssistant = getLastAssistantMessage(messages);
+		if (!lastAssistant || !Array.isArray(lastAssistant.content)) return undefined;
+
+		const text = lastAssistant.content
+			.filter(
+				(part): part is { type: "text"; text: string } =>
+					typeof part === "object" &&
+					part !== null &&
+					part.type === "text" &&
+					typeof part.text === "string" &&
+					part.text.trim().length > 0,
+			)
+			.map((part) => part.text.trim())
+			.join("\n")
+			.trim();
+
+		if (text.length === 0) return undefined;
+		return text.length > ASSISTANT_RESPONSE_MAX_LENGTH
+			? `${text.slice(0, ASSISTANT_RESPONSE_MAX_LENGTH - 3)}...`
+			: text;
+	};
+
 	pi.on("agent_end", async (event) => {
 		const durationMs = Date.now() - runState.startedAt;
 		const runError = summarizeRunError(event.messages, runState.firstToolError);
@@ -273,7 +297,14 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 		if (!shouldNotify(notifyLevel, subtitle)) {
 			return;
 		}
-		const body = runError || summarizeSuccess(runState, durationMs, thresholdMs);
+		let body = runError || summarizeSuccess(runState, durationMs, thresholdMs);
+
+		// Append LLM response text to notification body
+		const responseText = getAssistantResponseText(event.messages);
+		if (responseText) {
+			body = `${body}\n${responseText}`;
+		}
+
 		await sendNotification(subtitle, body);
 	});
 

--- a/extensions/cmux-notify.ts
+++ b/extensions/cmux-notify.ts
@@ -13,6 +13,7 @@ const DEFAULT_THRESHOLD_MS = 15000;
 const DEFAULT_DEBOUNCE_MS = 3000;
 const NOTIFY_TIMEOUT_MS = 5000;
 const DEFAULT_NOTIFY_LEVEL = "all";
+const DEFAULT_INCLUDE_ASSISTANT_RESPONSE = false;
 const ASSISTANT_RESPONSE_MAX_LENGTH = 500;
 
 type NotifyLevel = "all" | "medium" | "low" | "disabled";
@@ -38,6 +39,14 @@ function getNumberFromEnv(name: string, fallback: number): number {
 	if (!value) return fallback;
 	const parsed = Number.parseInt(value, 10);
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function getBooleanFromEnv(name: string, fallback: boolean): boolean {
+	const value = process.env[name]?.trim().toLowerCase();
+	if (!value) return fallback;
+	if (value === "1" || value === "true" || value === "yes" || value === "on") return true;
+	if (value === "0" || value === "false" || value === "no" || value === "off") return false;
+	return fallback;
 }
 
 function getNotifyLevelFromEnv(): NotifyLevel {
@@ -140,7 +149,7 @@ function getLastAssistantMessage(messages: readonly unknown[]): AssistantMessage
 	return undefined;
 }
 
-function summarizeAssistantText(message: AssistantMessageLike): string | undefined {
+function extractAssistantText(message: AssistantMessageLike): string | undefined {
 	if (!Array.isArray(message.content)) return undefined;
 
 	const text = message.content
@@ -156,8 +165,26 @@ function summarizeAssistantText(message: AssistantMessageLike): string | undefin
 		.join("\n")
 		.trim();
 
-	if (text.length === 0) return undefined;
-	return text.length > 120 ? `${text.slice(0, 117)}...` : text;
+	return text.length > 0 ? text : undefined;
+}
+
+function truncateText(text: string, maxLength: number): string {
+	return text.length > maxLength ? `${text.slice(0, maxLength - 3)}...` : text;
+}
+
+function summarizeAssistantText(message: AssistantMessageLike): string | undefined {
+	const text = extractAssistantText(message);
+	return text ? truncateText(text, 120) : undefined;
+}
+
+function getAssistantResponseText(messages: readonly unknown[]): string | undefined {
+	const lastAssistant = getLastAssistantMessage(messages);
+	if (!lastAssistant || (lastAssistant.stopReason !== "stop" && lastAssistant.stopReason !== "length")) {
+		return undefined;
+	}
+
+	const text = extractAssistantText(lastAssistant);
+	return text ? truncateText(text, ASSISTANT_RESPONSE_MAX_LENGTH) : undefined;
 }
 
 function summarizeRunError(messages: readonly unknown[], fallbackError?: string): string | undefined {
@@ -200,6 +227,7 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 	const thresholdMs = getNumberFromEnv("PI_CMUX_NOTIFY_THRESHOLD_MS", DEFAULT_THRESHOLD_MS);
 	const debounceMs = getNumberFromEnv("PI_CMUX_NOTIFY_DEBOUNCE_MS", DEFAULT_DEBOUNCE_MS);
 	const notifyLevel = getNotifyLevelFromEnv();
+	const includeAssistantResponse = getBooleanFromEnv("PI_CMUX_NOTIFY_INCLUDE_RESPONSE", DEFAULT_INCLUDE_ASSISTANT_RESPONSE);
 	const title = process.env.PI_CMUX_NOTIFY_TITLE || "Pi";
 
 	let runState = createEmptyRunState();
@@ -267,29 +295,6 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 		}
 	});
 
-	const getAssistantResponseText = (messages: readonly unknown[]): string | undefined => {
-		const lastAssistant = getLastAssistantMessage(messages);
-		if (!lastAssistant || !Array.isArray(lastAssistant.content)) return undefined;
-
-		const text = lastAssistant.content
-			.filter(
-				(part): part is { type: "text"; text: string } =>
-					typeof part === "object" &&
-					part !== null &&
-					part.type === "text" &&
-					typeof part.text === "string" &&
-					part.text.trim().length > 0,
-			)
-			.map((part) => part.text.trim())
-			.join("\n")
-			.trim();
-
-		if (text.length === 0) return undefined;
-		return text.length > ASSISTANT_RESPONSE_MAX_LENGTH
-			? `${text.slice(0, ASSISTANT_RESPONSE_MAX_LENGTH - 3)}...`
-			: text;
-	};
-
 	pi.on("agent_end", async (event) => {
 		const durationMs = Date.now() - runState.startedAt;
 		const runError = summarizeRunError(event.messages, runState.firstToolError);
@@ -299,10 +304,11 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 		}
 		let body = runError || summarizeSuccess(runState, durationMs, thresholdMs);
 
-		// Append LLM response text to notification body
-		const responseText = getAssistantResponseText(event.messages);
-		if (responseText) {
-			body = `${body}\n${responseText}`;
+		if (!runError && includeAssistantResponse) {
+			const responseText = getAssistantResponseText(event.messages);
+			if (responseText) {
+				body = `${body}\n${responseText}`;
+			}
 		}
 
 		await sendNotification(subtitle, body);


### PR DESCRIPTION

   ## Summary

   Currently, the `cmux-notify` extension sends desktop notifications with only a summary of file changes (e.g., "Updated file.ts in 2m 30s"). Users need to switch to the terminal to see what the LLM actually responded.

   This PR appends the last assistant message text (up to 500 characters) to the notification body, so users can preview the LLM response directly in the notification.

   ## Changes

   - Added `ASSISTANT_RESPONSE_MAX_LENGTH` constant (default: 500 chars)
   - Added `getAssistantResponseText()` helper to extract text from the last assistant message
   - Modified `agent_end` handler to append LLM response to the notification body

   ## Fallback Behavior

   When no assistant text is available (e.g., tool-only runs with no text response, empty content), the notification body falls back to the original summary (file changes, duration, etc.) without any modification. The
 LLM response is only appended when present.

   ## Example

   **Before:**
 ```

 Title: Pi
 Subtitle: Task Complete
 Body: Updated file.ts in 2m 30s

 ```

   **After (with LLM response):**
 ```

 Title: Pi
 Subtitle: Task Complete
 Body: Updated file.ts in 2m 30s
 I have refactored the authentication module to use JWT tokens instead of session-based auth. The main changes include...

 ```

   **After (no LLM response - fallback):**
 ```

 Title: Pi
 Subtitle: Task Complete
 Body: Updated file.ts in 2m 30s

 ```
