### PR TITLE
Wait for Pi to settle before notifying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,6 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npm test
       - run: npm run typecheck
       - run: npm run pack:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 This repository contains `pi-cmux`, a small Pi package that adds cmux-powered terminal workflows to Pi.
 
 Current extensions:
-- `extensions/cmux-notify.ts` — sends `cmux notify` alerts when Pi finishes, waits for input, or ends in an error/abort state
+- `extensions/cmux-notify.ts`: sends `cmux notify` alerts after Pi fully settles in a wait, completion, error, or abort state
 - `extensions/cmux-split.ts` — adds split commands that open a new cmux pane and start a fresh Pi session in the same working directory
 - `extensions/cmux-zoxide.ts` — adds zoxide-based split commands that jump to a matched directory and start Pi there
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.1.17] - 2026-08-13
+
+### Changed
+
+- Wait for Pi's `agent_settled` event before notifications, final sidebar states, and surface flashes.
+- Require Pi 0.80.5 or later, which provides the settled lifecycle event.
+
+### Fixed
+
+- Prevent retryable provider errors, automatic compaction, and queued continuations from creating premature completion or error notifications.
+- Preserve file activity and elapsed time across retries until Pi fully settles.
+
 ## [0.1.16] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Or install/update with the package installer:
 npx pi-cmux
 ```
 
+Pi 0.80.5 or later is required.
+
 If Pi is already running:
 
 ```text
@@ -34,8 +36,8 @@ If Pi is already running:
 
 | Workflow | Commands | Summary |
 |---|---|---|
-| Notifications | automatic | Sends `cmux notify` when Pi waits, completes work, or errors. |
-| Sidebar status/log | automatic | Updates cmux status, progress, logs, and surface flash while Pi runs. |
+| Notifications | automatic | Sends `cmux notify` after Pi fully settles with a wait, completion, or error state. |
+| Sidebar status/log | automatic | Updates live cmux state, then shows the final state after Pi fully settles. |
 | Split Pi | `/cmv [prompt]`, `/cmh [prompt]` | Opens a new right/lower split with Pi in the same project. |
 | Run a tool | `/cmo <cmd>`, `/cmoh <cmd>`, `/cmt <cmd>` | Opens a split or tab and runs a shell command in the same project. |
 | Pluggable tools | custom `/<name>` | Registers cmux split shortcuts from `pi-cmux.commands` settings. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@ Detailed usage for the cmux integrations bundled with `pi-cmux`.
 
 ## Notifications
 
-`cmux-notify` sends `cmux notify` alerts when Pi finishes a run.
+`cmux-notify` sends `cmux notify` alerts after Pi fully settles. It waits for retries, automatic compaction, and queued continuations.
 
 Notification fields:
 - title: `Pi` by default
@@ -37,7 +37,7 @@ It uses:
 - `cmux set-status` for a temporary Pi status pill while Pi is running, using tools, waiting, done, or errored
 - `cmux set-progress` for coarse run progress and live token counts while Pi is active
 - `cmux log` for run starts, changed files, warnings, final summaries, and compact session token counts, with cached input split out
-- `cmux trigger-flash` when a run finishes and the surface needs attention
+- `cmux trigger-flash` after Pi fully settles and the surface needs attention
 
 Environment settings:
 

--- a/extensions/cmux-notify.ts
+++ b/extensions/cmux-notify.ts
@@ -234,6 +234,7 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 	let lastNotificationAt = 0;
 	let lastNotificationKey = "";
 	let cmuxUnavailable = false;
+	let pendingMessages: readonly unknown[] | undefined;
 
 	const sendNotification = async (subtitle: string, body: string): Promise<{ ok: boolean; error?: string }> => {
 		if (cmuxUnavailable) {
@@ -264,8 +265,13 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 		return { ok: true };
 	};
 
-	pi.on("agent_start", async () => {
+	pi.on("before_agent_start", async () => {
+		// Automatic retries emit agent_start again, so reset state at the top-level prompt boundary.
 		runState = createEmptyRunState();
+	});
+
+	pi.on("agent_start", async () => {
+		pendingMessages = undefined;
 	});
 
 	pi.on("tool_result", async (event) => {
@@ -296,8 +302,16 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("agent_end", async (event) => {
+		pendingMessages = event.messages;
+	});
+
+	pi.on("agent_settled", async () => {
+		const messages = pendingMessages;
+		pendingMessages = undefined;
+		if (!messages) return;
+
 		const durationMs = Date.now() - runState.startedAt;
-		const runError = summarizeRunError(event.messages, runState.firstToolError);
+		const runError = summarizeRunError(messages, runState.firstToolError);
 		const subtitle = buildSubtitle(Boolean(runError), runState, durationMs, thresholdMs);
 		if (!shouldNotify(notifyLevel, subtitle)) {
 			return;
@@ -305,7 +319,7 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 		let body = runError || summarizeSuccess(runState, durationMs, thresholdMs);
 
 		if (!runError && includeAssistantResponse) {
-			const responseText = getAssistantResponseText(event.messages);
+			const responseText = getAssistantResponseText(messages);
 			if (responseText) {
 				body = `${body}\n${responseText}`;
 			}

--- a/extensions/cmux-sidebar.ts
+++ b/extensions/cmux-sidebar.ts
@@ -478,6 +478,7 @@ export default function cmuxSidebarExtension(pi: ExtensionAPI) {
 	let currentProgressValue: number | undefined;
 	let currentProgressLabel: string | undefined;
 	let lastTokenProgressUpdateAt = 0;
+	let pendingMessages: readonly unknown[] | undefined;
 
 	const markCmuxUnavailableIfFatal = (text: string): void => {
 		if (isCmuxUnavailableError(text)) {
@@ -611,28 +612,32 @@ export default function cmuxSidebarExtension(pi: ExtensionAPI) {
 		latestTokenSummary = undefined;
 		agentActive = false;
 		activeToolCount = 0;
+		pendingMessages = undefined;
 		clearProgress();
 		clearStatus();
 	});
 
 	pi.on("before_agent_start", async (event) => {
 		pendingPrompt = event.prompt ? truncateText(event.prompt, MAX_PROMPT_LENGTH) : undefined;
+		// Automatic retries emit agent_start again, so reset state at the top-level prompt boundary.
+		runState = createEmptyRunState(pendingPrompt);
 	});
 
 	pi.on("agent_start", async (_event, ctx) => {
 		runSequence += 1;
 		agentActive = true;
 		cancelFinalClear();
-		runState = createEmptyRunState(pendingPrompt);
+		const prompt = pendingPrompt;
 		pendingPrompt = undefined;
 		tokenBaseTotals = tokenTrackingEnabled ? getBranchTokenTotals(ctx.sessionManager.getBranch()) : createEmptyTokenTotals();
 		tokenRunTotals = createEmptyTokenTotals();
 		liveAssistantUsage = undefined;
 		activeToolCount = 0;
+		pendingMessages = undefined;
 		updateLatestTokenSummary(tokenBaseTotals);
 		setStatus("running", "Pi running");
 		setProgress(0.08, "Starting");
-		appendLog("progress", includePromptInLog && runState.prompt ? `Started: ${runState.prompt}` : "Run started");
+		appendLog("progress", includePromptInLog && prompt ? `Started: ${prompt}` : "Run started");
 	});
 
 	pi.on("turn_start", async (event) => {
@@ -713,12 +718,20 @@ export default function cmuxSidebarExtension(pi: ExtensionAPI) {
 	pi.on("agent_end", async (event) => {
 		agentActive = false;
 		activeToolCount = 0;
+		pendingMessages = event.messages;
+	});
+
+	pi.on("agent_settled", async () => {
+		const messages = pendingMessages;
+		pendingMessages = undefined;
+		if (!messages) return;
+
 		const durationMs = Date.now() - runState.startedAt;
-		const failure = summarizeRunFailure(event.messages, runState.firstToolError);
+		const failure = summarizeRunFailure(messages, runState.firstToolError);
 		const finalState = buildFinalState(failure, runState, durationMs, thresholdMs);
 		const summary = failure?.summary || summarizeSuccess(runState, durationMs, thresholdMs);
 		if (tokenTrackingEnabled) {
-			tokenRunTotals = getSessionTokenTotals(event.messages);
+			tokenRunTotals = getSessionTokenTotals(messages);
 			liveAssistantUsage = undefined;
 			updateLatestTokenSummary(addTokenTotals(tokenBaseTotals, tokenRunTotals));
 		} else {
@@ -756,6 +769,7 @@ export default function cmuxSidebarExtension(pi: ExtensionAPI) {
 		runSequence += 1;
 		agentActive = false;
 		activeToolCount = 0;
+		pendingMessages = undefined;
 		cancelFinalClear();
 		clearProgress();
 		clearStatus();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,35 +1,35 @@
 {
   "name": "pi-cmux",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-cmux",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "bin": {
         "pi-cmux": "install.mjs"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "0.75.5",
+        "@earendil-works/pi-coding-agent": "0.80.5",
         "typescript": "5.9.3"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": "*"
+        "@earendil-works/pi-coding-agent": ">=0.80.5"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.5.tgz",
-      "integrity": "sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==",
+      "version": "0.80.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.5.tgz",
+      "integrity": "sha512-GPYFuHw1BN+3m5Gzw1HGH41WdFDzbplLauS0zYSf1ZOkgKFd6wtEAcjchB/vmz9YtTGbQOwECbsVj6GxZxungA==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.75.5",
-        "@earendil-works/pi-ai": "^0.75.5",
-        "@earendil-works/pi-tui": "^0.75.5",
+        "@earendil-works/pi-agent-core": "^0.80.5",
+        "@earendil-works/pi-ai": "^0.80.5",
+        "@earendil-works/pi-tui": "^0.80.5",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -41,8 +41,9 @@
         "jiti": "2.7.0",
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
         "typebox": "1.1.38",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -52,7 +53,7 @@
         "node": ">=22.19.0"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard": "0.3.6"
+        "@mariozechner/clipboard": "0.3.9"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
@@ -518,12 +519,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+      "version": "0.80.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-ai": "^0.80.5",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -533,15 +534,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "version": "0.80.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -557,13 +559,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+      "version": "0.80.5",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -595,9 +597,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
-      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -605,22 +607,22 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
-        "@mariozechner/clipboard-darwin-universal": "0.3.6",
-        "@mariozechner/clipboard-darwin-x64": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
-      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
       "cpu": [
         "arm64"
       ],
@@ -635,9 +637,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
-      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -649,9 +651,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
-      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
       "cpu": [
         "x64"
       ],
@@ -666,13 +668,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
-      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,13 +688,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
-      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,13 +708,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
-      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,13 +728,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
-      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -734,13 +748,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
-      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -751,9 +768,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
-      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
       "cpu": [
         "arm64"
       ],
@@ -768,9 +785,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
-      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
       "cpu": [
         "x64"
       ],
@@ -785,15 +802,24 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
@@ -808,6 +834,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -831,9 +877,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -851,13 +897,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1504,16 +1543,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -1705,9 +1744,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1715,15 +1754,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1759,6 +1797,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1825,9 +1876,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1868,9 +1919,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-cmux",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Pi package with cmux-powered terminal integrations",
   "author": "Javi Molina",
   "license": "MIT",
@@ -25,7 +25,8 @@
     "pi-cmux": "install.mjs"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --allowImportingTsExtensions --skipLibCheck --strict extensions/*.ts",
+    "test": "node --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --allowImportingTsExtensions --skipLibCheck --strict extensions/*.ts tests/*.ts",
     "pack:check": "npm pack --dry-run"
   },
   "files": [
@@ -44,10 +45,10 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": ">=0.80.5"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.75.5",
+    "@earendil-works/pi-coding-agent": "0.80.5",
     "typescript": "5.9.3"
   }
 }

--- a/tests/settled-lifecycle.test.ts
+++ b/tests/settled-lifecycle.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import cmuxNotifyExtension from "../extensions/cmux-notify.ts";
+import cmuxSidebarExtension from "../extensions/cmux-sidebar.ts";
+
+type EventHandler = (event: Record<string, unknown>, context: ExtensionContext) => Promise<unknown> | unknown;
+
+interface ExecCall {
+	command: string;
+	args: string[];
+}
+
+const managedEnvironment = [
+	"CMUX_WORKSPACE_ID",
+	"PI_CMUX_NOTIFY_LEVEL",
+	"PI_CMUX_NOTIFY_THRESHOLD_MS",
+	"PI_CMUX_SIDEBAR_COMPLETE_THRESHOLD_MS",
+	"PI_CMUX_SIDEBAR_FINAL_CLEAR_MS",
+	"PI_CMUX_SIDEBAR_FLASH",
+	"PI_CMUX_SIDEBAR_TOKENS",
+] as const;
+
+const originalEnvironment = new Map(managedEnvironment.map((name) => [name, process.env[name]]));
+
+afterEach(() => {
+	for (const name of managedEnvironment) {
+		const value = originalEnvironment.get(name);
+		if (value === undefined) {
+			delete process.env[name];
+		} else {
+			process.env[name] = value;
+		}
+	}
+});
+
+function createHarness() {
+	const handlers = new Map<string, EventHandler[]>();
+	const execCalls: ExecCall[] = [];
+	const context = {
+		sessionManager: {
+			getBranch: () => [],
+		},
+	} as unknown as ExtensionContext;
+
+	const pi = {
+		on(event: string, handler: EventHandler) {
+			const eventHandlers = handlers.get(event) ?? [];
+			eventHandlers.push(handler);
+			handlers.set(event, eventHandlers);
+		},
+		async exec(command: string, args: string[]) {
+			execCalls.push({ command, args });
+			return { code: 0, stdout: "", stderr: "", killed: false };
+		},
+	} as unknown as ExtensionAPI;
+
+	const emit = async (type: string, event: Record<string, unknown> = {}): Promise<void> => {
+		for (const handler of handlers.get(type) ?? []) {
+			await handler({ type, ...event }, context);
+		}
+	};
+
+	return { pi, emit, execCalls };
+}
+
+function assistantMessage(stopReason: "stop" | "error", errorMessage?: string) {
+	return {
+		role: "assistant",
+		stopReason,
+		errorMessage,
+		content: [],
+	};
+}
+
+function successfulWrite(path: string) {
+	return {
+		toolName: "write",
+		toolCallId: "write-1",
+		input: { path },
+		content: [{ type: "text", text: "Wrote file" }],
+		details: {},
+		isError: false,
+	};
+}
+
+function getArgument(args: string[], name: string): string | undefined {
+	const index = args.indexOf(name);
+	return index >= 0 ? args[index + 1] : undefined;
+}
+
+async function drainQueuedCommands(): Promise<void> {
+	for (let index = 0; index < 4; index += 1) {
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+}
+
+test("notification preserves activity until settlement after a retry", async () => {
+	process.env.PI_CMUX_NOTIFY_LEVEL = "medium";
+	delete process.env.PI_CMUX_NOTIFY_THRESHOLD_MS;
+	const harness = createHarness();
+	cmuxNotifyExtension(harness.pi);
+
+	await harness.emit("before_agent_start", { prompt: "Update the file" });
+	await harness.emit("agent_start");
+	await harness.emit("tool_result", successfulWrite("/tmp/first-attempt.ts"));
+	await harness.emit("agent_end", {
+		messages: [assistantMessage("error", "Anthropic stream ended before message_stop")],
+	});
+	assert.equal(harness.execCalls.length, 0);
+
+	await harness.emit("agent_start");
+	await harness.emit("agent_end", { messages: [assistantMessage("stop")] });
+	assert.equal(harness.execCalls.length, 0);
+
+	await harness.emit("agent_settled");
+	assert.equal(harness.execCalls.length, 1);
+	assert.equal(harness.execCalls[0]?.command, "cmux");
+	assert.equal(getArgument(harness.execCalls[0]?.args ?? [], "--subtitle"), "Task Complete");
+	assert.equal(getArgument(harness.execCalls[0]?.args ?? [], "--body"), "Updated first-attempt.ts");
+});
+
+test("notification reports an error after final settlement", async () => {
+	process.env.PI_CMUX_NOTIFY_LEVEL = "all";
+	const harness = createHarness();
+	cmuxNotifyExtension(harness.pi);
+
+	await harness.emit("before_agent_start", { prompt: "Run the task" });
+	await harness.emit("agent_start");
+	await harness.emit("agent_end", {
+		messages: [assistantMessage("error", "Anthropic stream ended before message_stop")],
+	});
+	assert.equal(harness.execCalls.length, 0);
+
+	await harness.emit("agent_settled");
+	assert.equal(harness.execCalls.length, 1);
+	assert.equal(getArgument(harness.execCalls[0]?.args ?? [], "--subtitle"), "Error");
+	assert.equal(
+		getArgument(harness.execCalls[0]?.args ?? [], "--body"),
+		"Anthropic stream ended before message_stop",
+	);
+});
+
+test("sidebar waits for settlement before its final state", async () => {
+	process.env.CMUX_WORKSPACE_ID = "workspace-test";
+	delete process.env.PI_CMUX_SIDEBAR_COMPLETE_THRESHOLD_MS;
+	process.env.PI_CMUX_SIDEBAR_FINAL_CLEAR_MS = "60000";
+	process.env.PI_CMUX_SIDEBAR_FLASH = "disabled";
+	process.env.PI_CMUX_SIDEBAR_TOKENS = "0";
+	const harness = createHarness();
+	cmuxSidebarExtension(harness.pi);
+
+	await harness.emit("session_start", { reason: "startup" });
+	await drainQueuedCommands();
+	harness.execCalls.length = 0;
+
+	await harness.emit("before_agent_start", { prompt: "Update the file" });
+	await harness.emit("agent_start");
+	await drainQueuedCommands();
+	harness.execCalls.length = 0;
+
+	await harness.emit("tool_result", successfulWrite("/tmp/first-attempt.ts"));
+	await drainQueuedCommands();
+	harness.execCalls.length = 0;
+
+	await harness.emit("agent_end", {
+		messages: [assistantMessage("error", "Anthropic stream ended before message_stop")],
+	});
+	await drainQueuedCommands();
+	assert.equal(harness.execCalls.length, 0);
+
+	await harness.emit("agent_start");
+	await drainQueuedCommands();
+	harness.execCalls.length = 0;
+	await harness.emit("agent_end", { messages: [assistantMessage("stop")] });
+	await drainQueuedCommands();
+	assert.equal(harness.execCalls.length, 0);
+
+	await harness.emit("agent_settled");
+	await drainQueuedCommands();
+	assert.ok(
+		harness.execCalls.some(
+			(call) => call.args[0] === "set-status" && call.args.includes("Pi done"),
+		),
+	);
+	assert.ok(
+		harness.execCalls.some(
+			(call) => call.args[0] === "set-progress" && call.args[1] === "1.00" && call.args.includes("Done"),
+		),
+	);
+	assert.ok(
+		harness.execCalls.some(
+			(call) => call.args[0] === "log" && call.args.includes("Updated first-attempt.ts"),
+		),
+	);
+
+	await harness.emit("session_shutdown", { reason: "quit" });
+	await drainQueuedCommands();
+});


### PR DESCRIPTION
Fixes:
<img width="401" height="121" alt="image" src="https://github.com/user-attachments/assets/c7949dc0-0e25-421e-ac19-e102f3f4256b" />

Notice the badge appeared even though progress is still going. Because an error occurred at Anthropic which fired an `agnet_end`.

## Summary

- Waits for Pi's `agent_settled` event before cmux creates notifications or final sidebar states.
- Keeps retryable provider failures, automatic compaction, and queued continuations in the active state.
- Preserves file activity and elapsed time across retries until Pi reaches the final settled state.
- Adds lifecycle regression coverage for successful retries that include prior file activity, final errors, and sidebar state.
- Raises the minimum Pi version to 0.80.5 and prepares package version 0.1.17.

## Why

`agent_end` marks a low-level run boundary. Pi can still retry, compact context, or process a queued continuation after this event.

The old hook created an unread cmux badge before Pi finished. The sidebar then returned to an active state during the next run.

`agent_settled` fires only after all automatic work stops. It provides the completion boundary that these cmux integrations need.

`before_agent_start` now resets task activity once. Automatic `agent_start` events retain that activity through retries and compaction.

Related context: https://github.com/earendil-works/pi/issues/7350

## Compatibility

This release requires Pi 0.80.5 or later. That release is the first published package with `agent_settled` support.
