### PR TITLE
feat: conversation-driven tab titles (in-process LLM, on by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Added opt-in conversation tab titles (`PI_CMUX_AUTOTITLE=1`): after the first agent turn, the current cmux tab is renamed to a short topic title summarized by a headless `pi --print --no-tools` run. Tab-only (never renames the workspace), `/name` wins, `/new` resets. `PI_CMUX_AUTOTITLE_MODEL` selects the summarizer model.
+- Added opt-in conversation tab titles (`PI_CMUX_AUTOTITLE=1`): after the first agent turn, the current cmux tab is renamed to a short topic title summarized by a single in-process LLM call (compact transcript, short system prompt; no headless `pi` child, so no `pi -r` entries, no extra cmux notifications, and minimal token usage). Tab-only (never renames the workspace), `/name` wins, `/new` resets. `PI_CMUX_AUTOTITLE_MODEL` selects the summarizer model.
+- Dev dependency `@earendil-works/pi-coding-agent` bumped to 0.83.0 (with `@earendil-works/pi-ai` for the streaming API) to match current pi.
 
 ## [0.1.20] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added opt-in conversation tab titles (`PI_CMUX_AUTOTITLE=1`): after the first agent turn, the current cmux tab is renamed to a short topic title summarized by a single in-process LLM call (compact transcript, short system prompt; no headless `pi` child, so no `pi -r` entries, no extra cmux notifications, and minimal token usage). Tab-only (never renames the workspace), `/name` wins, `/new` resets. `PI_CMUX_AUTOTITLE_MODEL` selects the summarizer model.
+- Added conversation tab titles (on by default; opt out with `PI_CMUX_AUTOTITLE_DISABLED=1` or `"pi-cmux": { "autotitle": false }`): after the first agent turn, the current cmux tab is renamed to a short topic title summarized by a single in-process LLM call (compact transcript, short system prompt; no headless `pi` child, so no `pi -r` entries, no extra cmux notifications, and minimal token usage). Tab-only (never renames the workspace), `/name` wins, `/new` resets. `PI_CMUX_AUTOTITLE_MODEL` selects the summarizer model.
 - Dev dependency `@earendil-works/pi-coding-agent` bumped to 0.83.0 (with `@earendil-works/pi-ai` for the streaming API) to match current pi.
 
 ## [0.1.20] - 2026-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in conversation tab titles (`PI_CMUX_AUTOTITLE=1`): after the first agent turn, the current cmux tab is renamed to a short topic title summarized by a headless `pi --print --no-tools` run. Tab-only (never renames the workspace), `/name` wins, `/new` resets. `PI_CMUX_AUTOTITLE_MODEL` selects the summarizer model.
+
 ## [0.1.20] - 2026-09-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Detailed command examples: [docs/usage.md](docs/usage.md).
 | `PI_CMUX_SIDEBAR_TOKENS` | `1` | Include compact live cumulative session token counts in sidebar progress and summaries. |
 | `PI_CMUX_SIDEBAR_COST` | `0` | Include reported model cost alongside token counts. |
 | `PI_CMUX_SIDEBAR_LOG_TOOLS` | `0` | Set `1` to log every tool result. |
-| `PI_CMUX_AUTOTITLE` | `0` | Set `1` to name the current cmux tab after the conversation. |
+| `PI_CMUX_AUTOTITLE` | `0` | Set `1` to name the current cmux tab after the conversation. Can also be enabled via `"pi-cmux": { "autotitle": true }` in Pi settings (project-local `.pi/settings.json` wins over the global file). |
 | `PI_CMUX_AUTOTITLE_MODEL` | *(pi default)* | Model used by the in-process summarizer, e.g. `glm-5.3` or `anthropic/claude-haiku-4-5`. |
 
 With `PI_CMUX_AUTOTITLE=1`, the first agent turn of each conversation renames the current cmux tab to a 2-5 word topic title summarized by a single in-process LLM call (a compact transcript with a short system prompt - no headless `pi --print` child, so nothing is added to `pi -r`, no extra cmux notifications fire, and only the small transcript is sent). Only the tab is renamed - never the workspace - so it stays usable alongside cmux's built-in workspace auto-naming. `/name` overrides the automatic title, and `/new` clears it for the next conversation.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Detailed command examples: [docs/usage.md](docs/usage.md).
 | `PI_CMUX_SIDEBAR_COST` | `0` | Include reported model cost alongside token counts. |
 | `PI_CMUX_SIDEBAR_LOG_TOOLS` | `0` | Set `1` to log every tool result. |
 | `PI_CMUX_AUTOTITLE` | `0` | Set `1` to name the current cmux tab after the conversation. |
-| `PI_CMUX_AUTOTITLE_MODEL` | *(pi default)* | Model pattern used by the headless summarizer, e.g. `glm-5.3` or `anthropic/claude-haiku-*`. |
+| `PI_CMUX_AUTOTITLE_MODEL` | *(pi default)* | Model used by the in-process summarizer, e.g. `glm-5.3` or `anthropic/claude-haiku-4-5`. |
 
-With `PI_CMUX_AUTOTITLE=1`, the first agent turn of each conversation renames the current cmux tab to a 2-5 word topic title summarized by a headless `pi --print --no-tools` run. Only the tab is renamed - never the workspace - so it stays usable alongside cmux's built-in workspace auto-naming. `/name` overrides the automatic title, and `/new` clears it for the next conversation.
+With `PI_CMUX_AUTOTITLE=1`, the first agent turn of each conversation renames the current cmux tab to a 2-5 word topic title summarized by a single in-process LLM call (a compact transcript with a short system prompt - no headless `pi --print` child, so nothing is added to `pi -r`, no extra cmux notifications fire, and only the small transcript is sent). Only the tab is renamed - never the workspace - so it stays usable alongside cmux's built-in workspace auto-naming. `/name` overrides the automatic title, and `/new` clears it for the next conversation.
 
 Custom split shortcuts can be registered under `pi-cmux.commands` in `~/.pi/agent/settings.json` or `.pi/settings.json`; see [docs/usage.md](docs/usage.md#pluggable-tool-commands).
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Detailed command examples: [docs/usage.md](docs/usage.md).
 | `PI_CMUX_SIDEBAR_TOKENS` | `1` | Include compact live cumulative session token counts in sidebar progress and summaries. |
 | `PI_CMUX_SIDEBAR_COST` | `0` | Include reported model cost alongside token counts. |
 | `PI_CMUX_SIDEBAR_LOG_TOOLS` | `0` | Set `1` to log every tool result. |
+| `PI_CMUX_AUTOTITLE` | `0` | Set `1` to name the current cmux tab after the conversation. |
+| `PI_CMUX_AUTOTITLE_MODEL` | *(pi default)* | Model pattern used by the headless summarizer, e.g. `glm-5.3` or `anthropic/claude-haiku-*`. |
+
+With `PI_CMUX_AUTOTITLE=1`, the first agent turn of each conversation renames the current cmux tab to a 2-5 word topic title summarized by a headless `pi --print --no-tools` run. Only the tab is renamed - never the workspace - so it stays usable alongside cmux's built-in workspace auto-naming. `/name` overrides the automatic title, and `/new` clears it for the next conversation.
 
 Custom split shortcuts can be registered under `pi-cmux.commands` in `~/.pi/agent/settings.json` or `.pi/settings.json`; see [docs/usage.md](docs/usage.md#pluggable-tool-commands).
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Detailed command examples: [docs/usage.md](docs/usage.md).
 | `PI_CMUX_SIDEBAR_TOKENS` | `1` | Include compact live cumulative session token counts in sidebar progress and summaries. |
 | `PI_CMUX_SIDEBAR_COST` | `0` | Include reported model cost alongside token counts. |
 | `PI_CMUX_SIDEBAR_LOG_TOOLS` | `0` | Set `1` to log every tool result. |
-| `PI_CMUX_AUTOTITLE` | `0` | Set `1` to name the current cmux tab after the conversation. Can also be enabled via `"pi-cmux": { "autotitle": true }` in Pi settings (project-local `.pi/settings.json` wins over the global file). |
+| `PI_CMUX_AUTOTITLE_DISABLED` | `0` | Set `1` to opt out of naming the current cmux tab after the conversation. Can also be disabled via `"pi-cmux": { "autotitle": false }` in Pi settings (project-local `.pi/settings.json` wins over the global file). Enabled by default. |
 | `PI_CMUX_AUTOTITLE_MODEL` | *(pi default)* | Model used by the in-process summarizer, e.g. `glm-5.3` or `anthropic/claude-haiku-4-5`. |
 
-With `PI_CMUX_AUTOTITLE=1`, the first agent turn of each conversation renames the current cmux tab to a 2-5 word topic title summarized by a single in-process LLM call (a compact transcript with a short system prompt - no headless `pi --print` child, so nothing is added to `pi -r`, no extra cmux notifications fire, and only the small transcript is sent). Only the tab is renamed - never the workspace - so it stays usable alongside cmux's built-in workspace auto-naming. `/name` overrides the automatic title, and `/new` clears it for the next conversation.
+Tab titles are on by default: the first agent turn of each conversation renames the current cmux tab to a 2-5 word topic title summarized by a single in-process LLM call (a compact transcript with a short system prompt - no headless `pi --print` child, so nothing is added to `pi -r`, no extra cmux notifications fire, and only the small transcript is sent). Only the tab is renamed - never the workspace - so it stays usable alongside cmux's built-in workspace auto-naming. `/name` overrides the automatic title, and `/new` clears it for the next conversation. Opt out with `PI_CMUX_AUTOTITLE_DISABLED=1` or `"pi-cmux": { "autotitle": false }`.
 
 Custom split shortcuts can be registered under `pi-cmux.commands` in `~/.pi/agent/settings.json` or `.pi/settings.json`; see [docs/usage.md](docs/usage.md#pluggable-tool-commands).
 

--- a/extensions/cmux-autotitle.ts
+++ b/extensions/cmux-autotitle.ts
@@ -25,7 +25,7 @@ import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
 const SUMMARIZE_TIMEOUT_MS = 60_000;
 const SUMMARIZE_MAX_TOKENS = 1024;
 const MAX_MESSAGE_CHARS = 300;
-const MAX_CACHED_MESSAGES = 3;
+const MAX_CACHED_MESSAGES = 4;
 const MIN_MESSAGES_FOR_TITLE = 2;
 
 const TITLE_SYSTEM_PROMPT = [

--- a/extensions/cmux-autotitle.ts
+++ b/extensions/cmux-autotitle.ts
@@ -25,7 +25,7 @@ import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
 const SUMMARIZE_TIMEOUT_MS = 60_000;
 const SUMMARIZE_MAX_TOKENS = 1024;
 const MAX_MESSAGE_CHARS = 300;
-const MAX_CACHED_MESSAGES = 6;
+const MAX_CACHED_MESSAGES = 3;
 const MIN_MESSAGES_FOR_TITLE = 2;
 
 const TITLE_SYSTEM_PROMPT = [

--- a/extensions/cmux-autotitle.ts
+++ b/extensions/cmux-autotitle.ts
@@ -1,30 +1,39 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { spawn } from "node:child_process";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
 
 // Opt-in conversation-driven tab titles.
 //
 // After the first agent turn of a conversation, summarize the session into a
-// short topic title with a headless `pi --print --no-tools` run and rename the
-// current cmux tab. Workspace names are never touched, so this complements
-// cmux's built-in workspace auto-naming (which is skipped for workspaces with
-// a user-set name and always renames the workspace itself).
+// short topic title with a single in-process LLM call and rename the current
+// cmux tab. Workspace names are never touched, so this complements cmux's
+// built-in workspace auto-naming (which is skipped for workspaces with a
+// user-set name and always renames the workspace itself).
 //
 // Disabled by default; enable with PI_CMUX_AUTOTITLE=1.
 //
-// Three guards keep the headless summarizer safe (all verified the hard way):
-// - Headless children (`pi --print`) load this package too; the ctx.mode gate
-//   keeps them from re-entering the naming pass (infinite recursion).
-// - The child env drops CMUX_SURFACE_ID/CMUX_TAB_ID/CMUX_PANEL_ID and sets
-//   CMUX_PI_HOOKS_DISABLED=1, so it neither re-enters cmux hooks (notification
-//   storms) nor resolves to this surface.
-// - Headless pi waits for stdin EOF, so the child stdin must be ignored or it
-//   hangs until the timeout with empty output.
+// The summarizer deliberately does NOT spawn a headless `pi --print` child:
+// - A child writes a real session file, polluting `pi -r`.
+// - A child loads this package (and cmux hooks) again, re-triggering cmux
+//   notifications for the naming pass itself.
+// - A child pays the full pi system prompt (AGENTS.md, skills, ...) in tokens.
+// Instead we reuse pi's own streaming entry point (`completeSimple` from
+// pi-ai, the same completeSummarization uses internally) with a compact
+// transcript and a short system prompt: one standalone request, no session
+// file, no tool definitions, no child process.
 
-const SUMMARIZE_TIMEOUT_MS = 90_000;
+const SUMMARIZE_TIMEOUT_MS = 60_000;
+const SUMMARIZE_MAX_TOKENS = 1024;
 const MAX_MESSAGE_CHARS = 1500;
 const MAX_CACHED_MESSAGES = 6;
 const MIN_MESSAGES_FOR_TITLE = 2;
+
+const TITLE_SYSTEM_PROMPT = [
+	"You write tab titles for a coding session.",
+	"Summarize the conversation into a short title of 2-5 words in the conversation's primary language.",
+	"Describe the user's concrete goal, not the act of chatting; if the conversation contains pasted logs or code, describe the underlying goal instead of quoting the content.",
+	"Reply with the title only: no quotes, no trailing punctuation, no explanation.",
+].join(" ");
 
 interface CachedMessage {
 	role: "user" | "assistant";
@@ -35,6 +44,7 @@ let conversationTitle: string | undefined;
 let hasCustomName = false;
 let recentMessages: CachedMessage[] = [];
 let namingInFlight = false;
+let namingAbort: AbortController | undefined;
 
 function getBooleanFromEnv(name: string, fallback: boolean): boolean {
 	const value = process.env[name]?.trim().toLowerCase();
@@ -49,7 +59,7 @@ function isAutotitleEnabled(): boolean {
 }
 
 function isInteractive(ctx: ExtensionContext): boolean {
-	// Headless children load this extension too; never run there.
+	// Only the interactive TUI owns a cmux tab worth renaming.
 	return ctx.mode === "tui";
 }
 
@@ -91,61 +101,78 @@ function lastAssistantText(event: unknown): string | undefined {
 	return undefined;
 }
 
-function buildSummarizePrompt(): string | undefined {
+function buildTranscript(): string | undefined {
 	if (recentMessages.length < MIN_MESSAGES_FOR_TITLE) return undefined;
-	const lines = recentMessages
+	return recentMessages
 		.slice(-MAX_CACHED_MESSAGES)
-		.map((message) => `${message.role === "user" ? "User" : "Assistant"}: ${truncate(message.text, MAX_MESSAGE_CHARS)}`);
-	return [
-		"Summarize the conversation below into a short tab title of 2-5 words, written in the conversation's primary language.",
-		"Reply with the title only: no quotes, no trailing punctuation, no explanation.",
-		"If the conversation contains pasted logs or code, describe the underlying goal instead of quoting the content.",
-		"",
-		lines.join("\n"),
-	].join("\n");
+		.map((message) => `${message.role === "user" ? "User" : "Assistant"}: ${truncate(message.text, MAX_MESSAGE_CHARS)}`)
+		.join("\n");
 }
 
-function summarizeProcess(prompt: string, cwd: string): Promise<string> {
-	return new Promise((resolve) => {
-		// Sanitized environment: the headless child must not re-enter cmux hooks
-		// (notifications) or resolve to this surface.
-		const env: Record<string, string> = {};
-		for (const [key, value] of Object.entries(process.env)) {
-			if (value === undefined) continue;
-			if (key === "CMUX_SURFACE_ID" || key === "CMUX_TAB_ID" || key === "CMUX_PANEL_ID") continue;
-			env[key] = value;
-		}
-		env.CMUX_PI_HOOKS_DISABLED = "1";
+type SessionModel = NonNullable<ExtensionContext["model"]>;
 
-		let stdout = "";
-		let settled = false;
-		const finish = (): void => {
-			if (settled) return;
-			settled = true;
-			resolve(stdout);
-		};
+// Resolve PI_CMUX_AUTOTITLE_MODEL ("provider/model" or a bare model id)
+// against the session's model registry; fall back to the current model.
+function resolveSummarizerModel(ctx: ExtensionContext): SessionModel | undefined {
+	const requested = process.env.PI_CMUX_AUTOTITLE_MODEL?.trim();
+	if (!requested) return ctx.model ?? undefined;
+	const separator = requested.indexOf("/");
+	if (separator > 0) {
+		const provider = requested.slice(0, separator);
+		const modelId = requested.slice(separator + 1);
+		return ctx.modelRegistry.find(provider, modelId) ?? ctx.model ?? undefined;
+	}
+	for (const candidate of ctx.modelRegistry.getAvailable()) {
+		if (candidate.id === requested) return candidate;
+	}
+	return ctx.model ?? undefined;
+}
 
-		try {
-			const model = process.env.PI_CMUX_AUTOTITLE_MODEL?.trim();
-			const args = ["--print", "--no-tools"];
-			if (model) args.push("--model", model);
-			args.push(prompt);
-			const child = spawn("pi", args, {
-				cwd,
-				env,
-				timeout: SUMMARIZE_TIMEOUT_MS,
-				// Headless pi waits for stdin EOF unless it is closed explicitly.
-				stdio: ["ignore", "pipe", "pipe"],
-			});
-			child.stdout?.on("data", (chunk: Buffer) => {
-				stdout += chunk.toString("utf8");
-			});
-			child.on("error", () => finish());
-			child.on("close", () => finish());
-		} catch {
-			finish();
+// One standalone LLM call inside the pi process: no child session file, no
+// re-loaded extensions, no tool schemas, no full pi system prompt.
+async function summarizeInProcess(transcript: string, ctx: ExtensionContext): Promise<string | undefined> {
+	const model = resolveSummarizerModel(ctx);
+	if (!model) return undefined;
+
+	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	if (!auth.ok) return undefined;
+
+	const controller = new AbortController();
+	namingAbort = controller;
+	const timeout = setTimeout(() => controller.abort(), SUMMARIZE_TIMEOUT_MS);
+	try {
+		const message = await completeSimple(
+			model,
+			{
+				systemPrompt: TITLE_SYSTEM_PROMPT,
+				messages: [{ role: "user", content: transcript, timestamp: Date.now() }],
+			},
+			{
+				maxTokens: SUMMARIZE_MAX_TOKENS,
+				signal: controller.signal,
+				apiKey: auth.apiKey,
+				headers: auth.headers,
+				env: auth.env,
+				cacheRetention: "none",
+			},
+		);
+		const parts: string[] = [];
+		if (Array.isArray(message?.content)) {
+			for (const block of message.content) {
+				if ((block as { type?: unknown }).type === "text") {
+					const text = (block as { text?: unknown }).text;
+					if (typeof text === "string" && text.trim()) parts.push(text.trim());
+				}
+			}
 		}
-	});
+		// Models occasionally wrap the title in a fence, quotes, or a "Title:" label.
+		return parts.join("\n").trim() || undefined;
+	} catch {
+		return undefined;
+	} finally {
+		clearTimeout(timeout);
+		if (namingAbort === controller) namingAbort = undefined;
+	}
 }
 
 async function renameTab(pi: ExtensionAPI, title: string): Promise<void> {
@@ -164,11 +191,11 @@ async function renameTab(pi: ExtensionAPI, title: string): Promise<void> {
 }
 
 async function runNamingPass(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
-	const prompt = buildSummarizePrompt();
-	if (!prompt) return;
+	const transcript = buildTranscript();
+	if (!transcript) return;
 
-	const raw = await summarizeProcess(prompt, ctx.cwd);
-	const title = raw.trim() ? sanitizeTitle(raw) : undefined;
+	const raw = await summarizeInProcess(transcript, ctx);
+	const title = raw ? sanitizeTitle(raw) : undefined;
 	if (!title) return;
 
 	conversationTitle = title;
@@ -196,6 +223,8 @@ export default function cmuxAutotitleExtension(pi: ExtensionAPI): void {
 
 	pi.on("before_agent_start", async (event, ctx) => {
 		if (!isInteractive(ctx)) return;
+		// The user moved on: don't let a stale naming pass rename the tab late.
+		namingAbort?.abort();
 		const prompt = (event as { prompt?: string } | undefined)?.prompt?.trim();
 		if (prompt) recentMessages.push({ role: "user", text: prompt });
 	});

--- a/extensions/cmux-autotitle.ts
+++ b/extensions/cmux-autotitle.ts
@@ -24,7 +24,7 @@ import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
 
 const SUMMARIZE_TIMEOUT_MS = 60_000;
 const SUMMARIZE_MAX_TOKENS = 1024;
-const MAX_MESSAGE_CHARS = 1500;
+const MAX_MESSAGE_CHARS = 300;
 const MAX_CACHED_MESSAGES = 6;
 const MIN_MESSAGES_FOR_TITLE = 2;
 
@@ -65,7 +65,13 @@ function isInteractive(ctx: ExtensionContext): boolean {
 
 function truncate(value: string, max: number): string {
 	const trimmed = value.replace(/\s+/g, " ").trim();
-	return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max)}...`;
+	if (trimmed.length <= max) return trimmed;
+	// Keep the head and the tail: important content tends to sit at the start
+	// (the request, the error) and the end (the outcome, the question) of a
+	// message, while the middle is usually detail.
+	const head = Math.ceil(max * 0.6);
+	const tail = Math.floor(max * 0.4) - 1; // minus the ellipsis
+	return `${trimmed.slice(0, head)}…${trimmed.slice(-tail)}`;
 }
 
 function sanitizeTitle(raw: string): string | undefined {

--- a/extensions/cmux-autotitle.ts
+++ b/extensions/cmux-autotitle.ts
@@ -13,8 +13,9 @@ import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
 // built-in workspace auto-naming (which is skipped for workspaces with a
 // user-set name and always renames the workspace itself).
 //
-// Disabled by default; enable with PI_CMUX_AUTOTITLE=1 or
-// `"pi-cmux": { "autotitle": true }` in Pi settings.
+// Disabled by default? No - enabled by default. Opt out with
+// PI_CMUX_AUTOTITLE_DISABLED=1 or `"pi-cmux": { "autotitle": false }` in Pi
+// settings. (PI_CMUX_AUTOTITLE=1 is still accepted as a no-op-style force-on.)
 //
 // The summarizer deliberately does NOT spawn a headless `pi --print` child:
 // - A child writes a real session file, polluting `pi -r`.
@@ -60,14 +61,16 @@ function getBooleanFromEnv(name: string, fallback: boolean): boolean {
 
 function isAutotitleEnabled(): boolean {
 	if (getBooleanFromEnv("PI_CMUX_AUTOTITLE", false)) return true;
-	return readAutotitleSetting();
+	if (getBooleanFromEnv("PI_CMUX_AUTOTITLE_DISABLED", false)) return false;
+	return readAutotitleSetting(true);
 }
 
-// `"pi-cmux": { "autotitle": true }` in ~/.pi/agent/settings.json or
+// `"pi-cmux": { "autotitle": false }` in ~/.pi/agent/settings.json or
 // <cwd>/.pi/settings.json - the same settings pattern `pi-cmux.commands`
 // uses. Project-local wins over the global file. A bad file or section is
-// ignored (falls back to disabled), never fatal.
-function readAutotitleSetting(): boolean {
+// ignored, never fatal. Defaults to `defaultEnabled` (on, unless the
+// disabled env var is set).
+function readAutotitleSetting(defaultEnabled: boolean): boolean {
 	for (const settingsPath of [join(homedir(), ".pi", "agent", "settings.json"), join(process.cwd(), ".pi", "settings.json")]) {
 		try {
 			if (!existsSync(settingsPath)) continue;
@@ -80,7 +83,7 @@ function readAutotitleSetting(): boolean {
 			// Ignore unreadable settings files.
 		}
 	}
-	return false;
+	return defaultEnabled;
 }
 
 function isInteractive(ctx: ExtensionContext): boolean {

--- a/extensions/cmux-autotitle.ts
+++ b/extensions/cmux-autotitle.ts
@@ -1,5 +1,8 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
 
 // Opt-in conversation-driven tab titles.
@@ -10,7 +13,8 @@ import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
 // built-in workspace auto-naming (which is skipped for workspaces with a
 // user-set name and always renames the workspace itself).
 //
-// Disabled by default; enable with PI_CMUX_AUTOTITLE=1.
+// Disabled by default; enable with PI_CMUX_AUTOTITLE=1 or
+// `"pi-cmux": { "autotitle": true }` in Pi settings.
 //
 // The summarizer deliberately does NOT spawn a headless `pi --print` child:
 // - A child writes a real session file, polluting `pi -r`.
@@ -55,7 +59,28 @@ function getBooleanFromEnv(name: string, fallback: boolean): boolean {
 }
 
 function isAutotitleEnabled(): boolean {
-	return getBooleanFromEnv("PI_CMUX_AUTOTITLE", false);
+	if (getBooleanFromEnv("PI_CMUX_AUTOTITLE", false)) return true;
+	return readAutotitleSetting();
+}
+
+// `"pi-cmux": { "autotitle": true }` in ~/.pi/agent/settings.json or
+// <cwd>/.pi/settings.json - the same settings pattern `pi-cmux.commands`
+// uses. Project-local wins over the global file. A bad file or section is
+// ignored (falls back to disabled), never fatal.
+function readAutotitleSetting(): boolean {
+	for (const settingsPath of [join(homedir(), ".pi", "agent", "settings.json"), join(process.cwd(), ".pi", "settings.json")]) {
+		try {
+			if (!existsSync(settingsPath)) continue;
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf8")) as Record<string, unknown> | null;
+			const section = parsed?.["pi-cmux"];
+			if (!section || typeof section !== "object" || Array.isArray(section)) continue;
+			const value = (section as { autotitle?: unknown }).autotitle;
+			if (typeof value === "boolean") return value;
+		} catch {
+			// Ignore unreadable settings files.
+		}
+	}
+	return false;
 }
 
 function isInteractive(ctx: ExtensionContext): boolean {

--- a/extensions/cmux-autotitle.ts
+++ b/extensions/cmux-autotitle.ts
@@ -1,0 +1,233 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { execCmux, formatTabTitle, getCallerInfo } from "./cmux-core.ts";
+
+// Opt-in conversation-driven tab titles.
+//
+// After the first agent turn of a conversation, summarize the session into a
+// short topic title with a headless `pi --print --no-tools` run and rename the
+// current cmux tab. Workspace names are never touched, so this complements
+// cmux's built-in workspace auto-naming (which is skipped for workspaces with
+// a user-set name and always renames the workspace itself).
+//
+// Disabled by default; enable with PI_CMUX_AUTOTITLE=1.
+//
+// Three guards keep the headless summarizer safe (all verified the hard way):
+// - Headless children (`pi --print`) load this package too; the ctx.mode gate
+//   keeps them from re-entering the naming pass (infinite recursion).
+// - The child env drops CMUX_SURFACE_ID/CMUX_TAB_ID/CMUX_PANEL_ID and sets
+//   CMUX_PI_HOOKS_DISABLED=1, so it neither re-enters cmux hooks (notification
+//   storms) nor resolves to this surface.
+// - Headless pi waits for stdin EOF, so the child stdin must be ignored or it
+//   hangs until the timeout with empty output.
+
+const SUMMARIZE_TIMEOUT_MS = 90_000;
+const MAX_MESSAGE_CHARS = 1500;
+const MAX_CACHED_MESSAGES = 6;
+const MIN_MESSAGES_FOR_TITLE = 2;
+
+interface CachedMessage {
+	role: "user" | "assistant";
+	text: string;
+}
+
+let conversationTitle: string | undefined;
+let hasCustomName = false;
+let recentMessages: CachedMessage[] = [];
+let namingInFlight = false;
+
+function getBooleanFromEnv(name: string, fallback: boolean): boolean {
+	const value = process.env[name]?.trim().toLowerCase();
+	if (!value) return fallback;
+	if (value === "1" || value === "true" || value === "yes" || value === "on") return true;
+	if (value === "0" || value === "false" || value === "no" || value === "off" || value === "disabled") return false;
+	return fallback;
+}
+
+function isAutotitleEnabled(): boolean {
+	return getBooleanFromEnv("PI_CMUX_AUTOTITLE", false);
+}
+
+function isInteractive(ctx: ExtensionContext): boolean {
+	// Headless children load this extension too; never run there.
+	return ctx.mode === "tui";
+}
+
+function truncate(value: string, max: number): string {
+	const trimmed = value.replace(/\s+/g, " ").trim();
+	return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max)}...`;
+}
+
+function sanitizeTitle(raw: string): string | undefined {
+	const title = raw
+		.replace(/^["'「『《\s]+|["'」』》\s]+$/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (!title) return undefined;
+	return formatTabTitle(title, "");
+}
+
+function lastAssistantText(event: unknown): string | undefined {
+	const messages = (event as { messages?: unknown } | undefined)?.messages;
+	if (!Array.isArray(messages)) return undefined;
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index] as { role?: unknown; content?: unknown } | undefined;
+		if (!message || message.role !== "assistant") continue;
+		const content = message.content;
+		const parts: string[] = [];
+		if (typeof content === "string") {
+			parts.push(content);
+		} else if (Array.isArray(content)) {
+			for (const block of content) {
+				if ((block as { type?: unknown } | undefined)?.type === "text") {
+					const text = (block as { text?: unknown }).text;
+					if (typeof text === "string") parts.push(text);
+				}
+			}
+		}
+		const text = parts.join("\n").trim();
+		if (text) return text;
+	}
+	return undefined;
+}
+
+function buildSummarizePrompt(): string | undefined {
+	if (recentMessages.length < MIN_MESSAGES_FOR_TITLE) return undefined;
+	const lines = recentMessages
+		.slice(-MAX_CACHED_MESSAGES)
+		.map((message) => `${message.role === "user" ? "User" : "Assistant"}: ${truncate(message.text, MAX_MESSAGE_CHARS)}`);
+	return [
+		"Summarize the conversation below into a short tab title of 2-5 words, written in the conversation's primary language.",
+		"Reply with the title only: no quotes, no trailing punctuation, no explanation.",
+		"If the conversation contains pasted logs or code, describe the underlying goal instead of quoting the content.",
+		"",
+		lines.join("\n"),
+	].join("\n");
+}
+
+function summarizeProcess(prompt: string, cwd: string): Promise<string> {
+	return new Promise((resolve) => {
+		// Sanitized environment: the headless child must not re-enter cmux hooks
+		// (notifications) or resolve to this surface.
+		const env: Record<string, string> = {};
+		for (const [key, value] of Object.entries(process.env)) {
+			if (value === undefined) continue;
+			if (key === "CMUX_SURFACE_ID" || key === "CMUX_TAB_ID" || key === "CMUX_PANEL_ID") continue;
+			env[key] = value;
+		}
+		env.CMUX_PI_HOOKS_DISABLED = "1";
+
+		let stdout = "";
+		let settled = false;
+		const finish = (): void => {
+			if (settled) return;
+			settled = true;
+			resolve(stdout);
+		};
+
+		try {
+			const model = process.env.PI_CMUX_AUTOTITLE_MODEL?.trim();
+			const args = ["--print", "--no-tools"];
+			if (model) args.push("--model", model);
+			args.push(prompt);
+			const child = spawn("pi", args, {
+				cwd,
+				env,
+				timeout: SUMMARIZE_TIMEOUT_MS,
+				// Headless pi waits for stdin EOF unless it is closed explicitly.
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+			child.stdout?.on("data", (chunk: Buffer) => {
+				stdout += chunk.toString("utf8");
+			});
+			child.on("error", () => finish());
+			child.on("close", () => finish());
+		} catch {
+			finish();
+		}
+	});
+}
+
+async function renameTab(pi: ExtensionAPI, title: string): Promise<void> {
+	const callerResult = await getCallerInfo(pi);
+	if (!callerResult.ok) return;
+	const { workspace_ref: workspaceRef, surface_ref: surfaceRef } = callerResult.caller;
+	await execCmux(pi, [
+		"rename-tab",
+		"--workspace",
+		workspaceRef,
+		"--surface",
+		surfaceRef,
+		"--title",
+		title,
+	]);
+}
+
+async function runNamingPass(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+	const prompt = buildSummarizePrompt();
+	if (!prompt) return;
+
+	const raw = await summarizeProcess(prompt, ctx.cwd);
+	const title = raw.trim() ? sanitizeTitle(raw) : undefined;
+	if (!title) return;
+
+	conversationTitle = title;
+	// Best-effort: losing the race with a closed tab is fine.
+	try {
+		await renameTab(pi, title);
+	} catch {
+		// Ignore rename failures.
+	}
+}
+
+export default function cmuxAutotitleExtension(pi: ExtensionAPI): void {
+	if (!isAutotitleEnabled()) return;
+
+	pi.on("session_start", async (event, ctx) => {
+		if (!isInteractive(ctx)) return;
+		const reason = (event as { reason?: string } | undefined)?.reason;
+		if (reason === "new" || reason === "fork") {
+			// New conversation: forget the old topic so the next turn re-titles.
+			conversationTitle = undefined;
+			hasCustomName = false;
+		}
+		recentMessages = [];
+	});
+
+	pi.on("before_agent_start", async (event, ctx) => {
+		if (!isInteractive(ctx)) return;
+		const prompt = (event as { prompt?: string } | undefined)?.prompt?.trim();
+		if (prompt) recentMessages.push({ role: "user", text: prompt });
+	});
+
+	pi.on("agent_end", async (event, ctx) => {
+		if (!isInteractive(ctx)) return;
+		const reply = lastAssistantText(event);
+		if (reply) recentMessages.push({ role: "assistant", text: reply });
+
+		// Title once per conversation; skip while a user-set name owns the tab.
+		if (conversationTitle || hasCustomName || namingInFlight) return;
+		namingInFlight = true;
+		try {
+			await runNamingPass(pi, ctx);
+		} finally {
+			namingInFlight = false;
+		}
+	});
+
+	// A user-set session display name (/name) always wins.
+	pi.on("session_info_changed", async (event, ctx) => {
+		if (!isInteractive(ctx)) return;
+		const name = (event as { name?: string } | undefined)?.name?.trim();
+		if (!name) return;
+		hasCustomName = true;
+		conversationTitle = name;
+		const title = sanitizeTitle(name);
+		if (!title) return;
+		try {
+			await renameTab(pi, title);
+		} catch {
+			// Ignore rename failures.
+		}
+	});
+}

--- a/extensions/cmux-core.ts
+++ b/extensions/cmux-core.ts
@@ -179,7 +179,7 @@ function collectSurfaceRefs(panes: CmuxPaneInfo[]): Set<string> {
 	return refs;
 }
 
-async function execCmux(pi: ExtensionAPI, args: string[]): Promise<CmuxExecResult> {
+export async function execCmux(pi: ExtensionAPI, args: string[]): Promise<CmuxExecResult> {
 	const result = await pi.exec("cmux", args, { timeout: CMUX_TIMEOUT_MS });
 	if (result.killed) {
 		return {
@@ -204,7 +204,7 @@ async function execCmux(pi: ExtensionAPI, args: string[]): Promise<CmuxExecResul
 	};
 }
 
-async function getCallerInfo(pi: ExtensionAPI): Promise<{ ok: true; caller: CmuxCallerContext } | { ok: false; error: string }> {
+export async function getCallerInfo(pi: ExtensionAPI): Promise<{ ok: true; caller: CmuxCallerContext } | { ok: false; error: string }> {
 	const result = await execCmux(pi, ["--json", "identify"]);
 	if (!result.ok) {
 		return { ok: false, error: result.error || "Failed to identify cmux caller" };

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -6,6 +6,7 @@ import cmuxReviewExtension from "./cmux-review.ts";
 import cmuxContinueExtension from "./cmux-continue.ts";
 import cmuxOpenExtension from "./cmux-open.ts";
 import cmuxSidebarExtension from "./cmux-sidebar.ts";
+import cmuxAutotitleExtension from "./cmux-autotitle.ts";
 import { initI18n } from "./i18n.ts";
 
 export default function piCmuxExtensionBundle(pi: ExtensionAPI) {
@@ -17,4 +18,5 @@ export default function piCmuxExtensionBundle(pi: ExtensionAPI) {
 	cmuxContinueExtension(pi);
 	cmuxOpenExtension(pi);
 	cmuxSidebarExtension(pi);
+	cmuxAutotitleExtension(pi);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "pi-cmux": "install.mjs"
       },
       "devDependencies": {
+        "@earendil-works/pi-ai": "0.85.1",
         "@earendil-works/pi-coding-agent": "0.85.1",
         "typescript": "5.9.3"
       },
@@ -20,6 +21,468 @@
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.85.1"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.81",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.34",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.29",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.52",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.10",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.123.0",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.85.1",
+        "@google/genai": "1.52.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
@@ -2415,10 +2878,614 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2427,6 +3494,39 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@earendil-works/pi-coding-agent": ">=0.85.1"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "0.85.1",
     "@earendil-works/pi-coding-agent": "0.85.1",
     "typescript": "5.9.3"
   }


### PR DESCRIPTION
## What

Conversation-driven tab titles, on by default. After the first agent turn of a conversation, the current cmux tab is renamed to a short (2-5 word) topic title, generated by a single **in-process** LLM call that reuses the session's model, auth, and model registry.

- On by default; opt out with `PI_CMUX_AUTOTITLE_DISABLED=1` or `"pi-cmux": { "autotitle": false }` in Pi settings (project-local `.pi/settings.json` wins over the global file).
- `PI_CMUX_AUTOTITLE_MODEL` optionally selects the summarizer model (resolved via the model registry; falls back to the current model).
- Tab-only: the workspace name is never touched, so this composes with cmux's built-in workspace auto-naming (which is skipped entirely for workspaces with a user-set name, and always renames the workspace itself).
- `/name` overrides the automatic title; `/new` clears it so the next conversation gets a fresh one.
- Runs after the turn ends, off the critical path; one summarizer call per conversation, aborted if the user starts a new turn first.

## Why

pi-cmux already owns tab naming for the splits it spawns (`renameSurfaceTab`), but the tab hosting the current session keeps the default `π - <folder>` title forever. cmux's native auto-naming (`automation.workspaceAutoNaming`) cannot fill this gap for users who set workspace names: the spawn gate skips user-owned workspaces, and when it does run it renames the workspace (window title) as well.

Enabled by default because opt-in features stay undiscovered — users who never read the README never meet them. The escape hatches above make it safe to default on.

## Implementation notes

The title is generated with one standalone `completeSimple` call (pi-ai's completion primitive, the same one compaction's `completeSummarization` wraps): a compact transcript (last 4 messages, each compressed to ~300 chars with a head/tail split around an ellipsis — requests and outcomes live at message edges, detail in the middle) with a short system prompt, model resolved from `ctx.modelRegistry`, auth from `getApiKeyAndHeaders`, `maxTokens` capped, `cacheRetention: "none"`, and an `AbortController` with a timeout. Input for the naming request is ~1k tokens even for resumed long sessions.

An earlier iteration used a headless `pi --print --no-tools` child. That approach was rejected for three reasons, each a real failure mode:

1. **`pi -r` pollution** — the headless child writes a real session file, so every titled conversation leaves a junk entry in the resume list.
2. **cmux notification storm** — the child loads this package (and the host's cmux hooks) again; the naming pass itself re-triggered `cmux notify`. Env-var kill switches only cover extensions that know about them.
3. **Token cost** — the child pays the full pi system prompt (AGENTS.md, skills, tool schemas) for what is a ~50-token answer.

The in-process call has none of these: no session file, no re-loaded extensions, and only the compact transcript is sent.

Failure budget: any failure (model resolution, auth, network, empty output, lost race with a closed tab) leaves state untouched so the next `agent_end` retries; nothing surfaces to the user and nothing blocks the conversation.

## Verification (done locally against cmux 0.64.22 / pi 0.83.0 on macOS)

- Live-tested end to end in cmux: first turn renames the tab; `/new` re-titles the next conversation; `/name` wins; tab-only, workspace untouched.
- `pi -r` stays clean (no summarizer session files); cmux notifications fire only for the main conversation.
- Extension loads cleanly under real pi (headless `pi --print` smoke test); config precedence verified unit-style (env force-on, env opt-out, settings true/false, bad JSON ignored).
- Repo typecheck script passes (`tsc --noEmit ... --strict extensions/*.ts`) against `@earendil-works/pi-coding-agent` 0.83.0 (devDependency bumped to match; adds `@earendil-works/pi-ai` at the same version).

## Docs

README config table + usage paragraph, CHANGELOG `[Unreleased]` entry.
