### PR TITLE
fix: bind sidebar status to cmux surface lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,6 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npm test
       - run: npm run typecheck
       - run: npm run pack:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Associate sidebar status with its cmux surface and Pi process so cmux removes stale status when a surface exits.
+
 ## [0.1.16] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-09-08
+
 ### Fixed
 
-- Associate sidebar status with its cmux surface and Pi process so cmux removes stale status when a surface exits.
+- Associate sidebar status with its cmux surface and Pi process so cmux can remove stale status after an exit.
+- Keep delayed, shutdown, and startup status cleanup targeting the owning surface after it moves to another workspace.
 
 ## [0.1.19] - 2026-09-07
 

--- a/extensions/cmux-sidebar.ts
+++ b/extensions/cmux-sidebar.ts
@@ -524,7 +524,8 @@ export default function cmuxSidebarExtension(pi: ExtensionAPI) {
 	};
 
 	const clearStatus = (): void => {
-		enqueueCmux(["clear-status", statusKey]);
+		// Follow the same owner as setStatus if the surface moves to another workspace.
+		enqueueCmux(["clear-status", statusKey, ...(panelId ? ["--panel", panelId] : [])]);
 	};
 
 	const appendLog = (level: LogLevel, message: string): void => {

--- a/extensions/cmux-sidebar.ts
+++ b/extensions/cmux-sidebar.ts
@@ -445,6 +445,7 @@ export default function cmuxSidebarExtension(pi: ExtensionAPI) {
 	}
 
 	const statusKey = getStatusKey();
+	const panelId = process.env.CMUX_SURFACE_ID?.trim() || process.env.CMUX_PANEL_ID?.trim();
 	const source = process.env.PI_CMUX_SIDEBAR_SOURCE?.trim() || "pi";
 	const priority = getNumberFromEnv("PI_CMUX_SIDEBAR_STATUS_PRIORITY", DEFAULT_STATUS_PRIORITY);
 	const thresholdMs = getNumberFromEnv(
@@ -524,6 +525,9 @@ export default function cmuxSidebarExtension(pi: ExtensionAPI) {
 			style.color,
 			"--priority",
 			String(priority),
+			...(panelId ? ["--panel", panelId] : []),
+			"--pid",
+			String(process.pid),
 		]);
 	};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-cmux",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-cmux",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "bin": {
         "pi-cmux": "install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-cmux",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Pi package with cmux-powered terminal integrations",
   "author": "Javi Molina",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pi-cmux": "install.mjs"
   },
   "scripts": {
+    "test": "node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --allowImportingTsExtensions --skipLibCheck --strict extensions/*.ts",
     "pack:check": "npm pack --dry-run"
   },

--- a/tests/cmux-sidebar.test.mjs
+++ b/tests/cmux-sidebar.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import ts from "typescript";
+
+const execFile = promisify(execFileCallback);
+const projectRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const sidebarSourcePath = join(projectRoot, "extensions", "cmux-sidebar.ts");
+
+async function createSidebarRuntime() {
+	const source = await readFile(sidebarSourcePath, "utf8");
+	const runtime = ts.transpileModule(source, {
+		compilerOptions: {
+			module: ts.ModuleKind.ESNext,
+			target: ts.ScriptTarget.ES2022,
+		},
+		fileName: sidebarSourcePath,
+	}).outputText;
+	const runtimePath = join(projectRoot, "extensions", `cmux-sidebar.test-${randomUUID()}.mjs`);
+	await writeFile(runtimePath, runtime);
+	return runtimePath;
+}
+
+async function runSidebar(environment) {
+	const runtimePath = await createSidebarRuntime();
+	const outputDirectory = await mkdtemp(join(tmpdir(), "pi-cmux-sidebar-test-"));
+	const outputPath = join(outputDirectory, "commands.json");
+	const childProgram = `
+		import sidebar from ${JSON.stringify(pathToFileURL(runtimePath).href)};
+		import { writeFileSync } from "node:fs";
+		const handlers = new Map();
+		const commands = [];
+		sidebar({
+			on(event, handler) { handlers.set(event, handler); },
+			async exec(command, args) {
+				commands.push({ command, args });
+				return { killed: false, code: 0, stdout: "", stderr: "" };
+			},
+		});
+		await handlers.get("agent_start")({}, { sessionManager: { getBranch: () => [] } });
+		await handlers.get("agent_end")({ messages: [] });
+		process.on("beforeExit", () => writeFileSync(${JSON.stringify(outputPath)}, JSON.stringify({ pid: process.pid, commands })));
+	`;
+
+	try {
+		await execFile(process.execPath, ["--input-type=module", "--eval", childProgram], {
+			env: {
+				...process.env,
+				CMUX_WORKSPACE_ID: "workspace-1",
+				PI_CMUX_SIDEBAR_FINAL_CLEAR_MS: "20",
+				...environment,
+			},
+		});
+		return JSON.parse(await readFile(outputPath, "utf8"));
+	} finally {
+		await rm(runtimePath, { force: true });
+		await rm(outputDirectory, { recursive: true, force: true });
+	}
+}
+
+function setStatusCommand(commands) {
+	return commands.filter(({ command }) => command === "cmux")
+		.map(({ args }) => args)
+		.find((args) => args[0] === "set-status");
+}
+
+test("sidebar statuses are owned by their cmux panel and Pi process", async () => {
+	const { pid, commands } = await runSidebar({ CMUX_SURFACE_ID: "surface-1" });
+	const setStatus = setStatusCommand(commands);
+
+	assert.ok(setStatus, "expected a cmux set-status command");
+	assert.deepEqual(setStatus.slice(-4), ["--panel", "surface-1", "--pid", String(pid)]);
+});
+
+test("sidebar statuses use panel identity when surface identity is unavailable", async () => {
+	const { pid, commands } = await runSidebar({
+		CMUX_SURFACE_ID: "",
+		CMUX_PANEL_ID: "panel-1",
+		CMUX_TAB_ID: "workspace-1",
+	});
+	const setStatus = setStatusCommand(commands);
+
+	assert.ok(setStatus, "expected a cmux set-status command");
+	assert.deepEqual(setStatus.slice(-4), ["--panel", "panel-1", "--pid", String(pid)]);
+});

--- a/tests/cmux-sidebar.test.mjs
+++ b/tests/cmux-sidebar.test.mjs
@@ -1,91 +1,185 @@
 import assert from "node:assert/strict";
-import { execFile as execFileCallback } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { setImmediate as waitForImmediate } from "node:timers/promises";
 import test from "node:test";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { promisify } from "node:util";
-import ts from "typescript";
+import cmuxSidebarExtension from "../extensions/cmux-sidebar.ts";
 
-const execFile = promisify(execFileCallback);
-const projectRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const sidebarSourcePath = join(projectRoot, "extensions", "cmux-sidebar.ts");
+const WORKSPACE_ID = "11111111-1111-4111-8111-111111111111";
+const MOVED_WORKSPACE_ID = "22222222-2222-4222-8222-222222222222";
+const SURFACE_ID = "33333333-3333-4333-8333-333333333333";
+const PANEL_ID = "44444444-4444-4444-8444-444444444444";
+const STATUS_KEY = "pi-cmux-test";
+const CLEAR_DELAY_MS = 20;
+const ERROR_MESSAGES = [{ role: "assistant", stopReason: "error", errorMessage: "Provider failed" }];
 
-async function createSidebarRuntime() {
-	const source = await readFile(sidebarSourcePath, "utf8");
-	const runtime = ts.transpileModule(source, {
-		compilerOptions: {
-			module: ts.ModuleKind.ESNext,
-			target: ts.ScriptTarget.ES2022,
-		},
-		fileName: sidebarSourcePath,
-	}).outputText;
-	const runtimePath = join(projectRoot, "extensions", `cmux-sidebar.test-${randomUUID()}.mjs`);
-	await writeFile(runtimePath, runtime);
-	return runtimePath;
+function option(args, name) {
+	const index = args.indexOf(name);
+	return index < 0 ? undefined : args[index + 1];
 }
 
-async function runSidebar(environment) {
-	const runtimePath = await createSidebarRuntime();
-	const outputDirectory = await mkdtemp(join(tmpdir(), "pi-cmux-sidebar-test-"));
-	const outputPath = join(outputDirectory, "commands.json");
-	const childProgram = `
-		import sidebar from ${JSON.stringify(pathToFileURL(runtimePath).href)};
-		import { writeFileSync } from "node:fs";
-		const handlers = new Map();
-		const commands = [];
-		sidebar({
-			on(event, handler) { handlers.set(event, handler); },
-			async exec(command, args) {
-				commands.push({ command, args });
-				return { killed: false, code: 0, stdout: "", stderr: "" };
-			},
-		});
-		await handlers.get("agent_start")({}, { sessionManager: { getBranch: () => [] } });
-		await handlers.get("agent_end")({ messages: [] });
-		process.on("beforeExit", () => writeFileSync(${JSON.stringify(outputPath)}, JSON.stringify({ pid: process.pid, commands })));
-	`;
+function createHarness() {
+	const handlers = new Map();
+	const commands = [];
+	const workspaces = new Map();
+	const panelId = process.env.CMUX_SURFACE_ID?.trim() || process.env.CMUX_PANEL_ID?.trim();
+	const panelOwners = new Map(panelId ? [[panelId, WORKSPACE_ID]] : []);
+	const ctx = { isIdle: () => true, sessionManager: { getBranch: () => [] } };
 
+	function statuses(workspace) {
+		if (!workspaces.has(workspace)) workspaces.set(workspace, new Map());
+		return workspaces.get(workspace);
+	}
+
+	cmuxSidebarExtension({
+		on(event, handler) { handlers.set(event, handler); },
+		async exec(command, args) {
+			// cmux follows an explicit panel's owner; without --panel it uses
+			// the caller's (possibly stale) CMUX_WORKSPACE_ID.
+			const ownerPanel = option(args, "--panel");
+			const workspace = ownerPanel ? panelOwners.get(ownerPanel) : process.env.CMUX_WORKSPACE_ID;
+			commands.push({ command, args, workspace });
+			if (command === "cmux" && workspace) {
+				if (args[0] === "set-status") {
+					statuses(workspace).set(args[1], { value: args[2], panelId: ownerPanel });
+				} else if (args[0] === "clear-status") {
+					statuses(workspace).delete(args[1]);
+				}
+			}
+			return { killed: false, code: 0, stdout: "", stderr: "" };
+		},
+	});
+
+	return {
+		commands,
+		statuses,
+		async emit(event, payload = {}) {
+			await handlers.get(event)(payload, ctx);
+			await waitForImmediate();
+		},
+		moveSurface(panel, workspace) {
+			const previous = statuses(panelOwners.get(panel));
+			for (const [key, entry] of previous) {
+				if (entry.panelId !== panel) continue;
+				statuses(workspace).set(key, entry);
+				previous.delete(key);
+			}
+			panelOwners.set(panel, workspace);
+		},
+	};
+}
+
+async function withSidebar(overrides, callback) {
+	const environment = {
+		CMUX_WORKSPACE_ID: WORKSPACE_ID,
+		CMUX_SURFACE_ID: SURFACE_ID,
+		CMUX_PANEL_ID: "",
+		CMUX_TAB_ID: "",
+		PI_CMUX_SIDEBAR: "1",
+		PI_CMUX_SIDEBAR_STATUS_KEY: STATUS_KEY,
+		PI_CMUX_SIDEBAR_FINAL_CLEAR_MS: String(CLEAR_DELAY_MS),
+		PI_CMUX_SIDEBAR_PROGRESS: "0",
+		PI_CMUX_SIDEBAR_TOKENS: "0",
+		PI_CMUX_SIDEBAR_FLASH: "0",
+		PI_CMUX_SIDEBAR_LOG_TOOLS: "0",
+		...overrides,
+	};
+	const previous = new Map();
+	for (const [name, value] of Object.entries(environment)) {
+		previous.set(name, process.env[name]);
+		if (value === undefined) delete process.env[name];
+		else process.env[name] = value;
+	}
+
+	let harness;
 	try {
-		await execFile(process.execPath, ["--input-type=module", "--eval", childProgram], {
-			env: {
-				...process.env,
-				CMUX_WORKSPACE_ID: "workspace-1",
-				PI_CMUX_SIDEBAR_FINAL_CLEAR_MS: "20",
-				...environment,
-			},
-		});
-		return JSON.parse(await readFile(outputPath, "utf8"));
+		harness = createHarness();
+		await callback(harness);
 	} finally {
-		await rm(runtimePath, { force: true });
-		await rm(outputDirectory, { recursive: true, force: true });
+		try {
+			await harness?.emit("session_shutdown");
+		} finally {
+			for (const [name, value] of previous) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+		}
 	}
 }
 
-function setStatusCommand(commands) {
-	return commands.filter(({ command }) => command === "cmux")
-		.map(({ args }) => args)
-		.find((args) => args[0] === "set-status");
+for (const { name, environment, panel } of [
+	{
+		name: "prefer trimmed surface identity over panel identity",
+		environment: { CMUX_SURFACE_ID: ` ${SURFACE_ID} `, CMUX_PANEL_ID: PANEL_ID },
+		panel: SURFACE_ID,
+	},
+	{
+		name: "fall back to trimmed panel identity",
+		environment: { CMUX_SURFACE_ID: " \t ", CMUX_PANEL_ID: ` ${PANEL_ID} ` },
+		panel: PANEL_ID,
+	},
+	{
+		name: "omit panel targeting when no identity is available",
+		environment: { CMUX_SURFACE_ID: undefined, CMUX_PANEL_ID: undefined },
+		panel: undefined,
+	},
+]) {
+	test(`sidebar statuses and clears ${name}`, async (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		await withSidebar(environment, async (harness) => {
+			await harness.emit("session_start");
+			await harness.emit("agent_start");
+			await harness.emit("turn_start", { turnIndex: 1 });
+			await harness.emit("tool_execution_start", { toolName: "bash", args: {} });
+			await harness.emit("tool_execution_end");
+			await harness.emit("agent_end", { messages: ERROR_MESSAGES });
+			await harness.emit("agent_settled");
+			await harness.emit("session_shutdown");
+
+			const panelArgs = panel ? ["--panel", panel] : [];
+			const statusCalls = harness.commands.filter(({ args }) => args[0] === "set-status");
+			assert.deepEqual(statusCalls.map(({ args }) => args[2]), [
+				"Pi running", "Pi turn 2", "Pi bash", "Pi thinking", "Pi error",
+			]);
+			for (const { args } of statusCalls) {
+				assert.equal(option(args, "--panel"), panel);
+				assert.deepEqual(args.slice(-(panelArgs.length + 2)), [...panelArgs, "--pid", String(process.pid)]);
+			}
+			const clearCalls = harness.commands.filter(({ args }) => args[0] === "clear-status");
+			assert.equal(clearCalls.length, 2);
+			for (const { args } of clearCalls) {
+				assert.deepEqual(args, ["clear-status", STATUS_KEY, ...panelArgs]);
+			}
+		});
+	});
 }
 
-test("sidebar statuses are owned by their cmux panel and Pi process", async () => {
-	const { pid, commands } = await runSidebar({ CMUX_SURFACE_ID: "surface-1" });
-	const setStatus = setStatusCommand(commands);
+for (const cleanup of ["final delay", "session_shutdown", "session_start"]) {
+	test(`sidebar ${cleanup} clears a surface moved to another workspace`, async (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		await withSidebar({}, async (harness) => {
+			await harness.emit("session_start");
+			await harness.emit("agent_start");
+			assert.equal(harness.statuses(WORKSPACE_ID).get(STATUS_KEY)?.value, "Pi running");
 
-	assert.ok(setStatus, "expected a cmux set-status command");
-	assert.deepEqual(setStatus.slice(-4), ["--panel", "surface-1", "--pid", String(pid)]);
-});
+			harness.moveSurface(SURFACE_ID, MOVED_WORKSPACE_ID);
+			assert.equal(process.env.CMUX_WORKSPACE_ID, WORKSPACE_ID, "Pi retains its original workspace environment");
+			assert.equal(harness.statuses(MOVED_WORKSPACE_ID).get(STATUS_KEY)?.value, "Pi running");
+			harness.statuses(WORKSPACE_ID).set(STATUS_KEY, { value: "Unrelated status", panelId: PANEL_ID });
 
-test("sidebar statuses use panel identity when surface identity is unavailable", async () => {
-	const { pid, commands } = await runSidebar({
-		CMUX_SURFACE_ID: "",
-		CMUX_PANEL_ID: "panel-1",
-		CMUX_TAB_ID: "workspace-1",
+			if (cleanup === "final delay") {
+				await harness.emit("agent_end", { messages: ERROR_MESSAGES });
+				await harness.emit("agent_settled");
+				assert.equal(harness.statuses(MOVED_WORKSPACE_ID).get(STATUS_KEY)?.value, "Pi error");
+				t.mock.timers.tick(CLEAR_DELAY_MS);
+				await waitForImmediate();
+			} else {
+				await harness.emit(cleanup);
+			}
+
+			assert.equal(harness.statuses(MOVED_WORKSPACE_ID).has(STATUS_KEY), false);
+			assert.equal(harness.statuses(WORKSPACE_ID).get(STATUS_KEY)?.value, "Unrelated status");
+			const clear = harness.commands.findLast(({ args }) => args[0] === "clear-status");
+			assert.equal(clear.workspace, MOVED_WORKSPACE_ID);
+			assert.deepEqual(clear.args, ["clear-status", STATUS_KEY, "--panel", SURFACE_ID]);
+		});
 	});
-	const setStatus = setStatusCommand(commands);
-
-	assert.ok(setStatus, "expected a cmux set-status command");
-	assert.deepEqual(setStatus.slice(-4), ["--panel", "panel-1", "--pid", String(pid)]);
-});
+}


### PR DESCRIPTION
Pi sessions that time out, crash, or are killed can exit before their delayed sidebar clear runs. Because the status carried no owner metadata, cmux could not associate stale `Pi error` and `Pi turn` entries with the closed surface.

- Attach the current cmux surface or panel and Pi PID to status updates
- Preserve delayed and shutdown clearing for normal completion
- Add behavioral coverage for surface ownership and panel fallback
- Run the regression tests in CI
