### PR TITLE
fix: only notify when Pi runs inside a cmux surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Notifications now only fire when Pi runs interactively inside a cmux surface (`ctx.mode === "tui"` plus `CMUX_SURFACE_ID`/`CMUX_PANEL_ID`). Headless and embedded Pi (SDK, `--print`, JSON, RPC) and terminals outside cmux stay silent instead of notifying through a running cmux app; opt back in with `PI_CMUX_NOTIFY_FORCE=1`.
+
 ## [0.1.20] - 2026-09-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If Pi is already running:
 
 | Workflow | Commands | Summary |
 |---|---|---|
-| Notifications | automatic | Sends `cmux notify` once Pi settles after retries, compaction, and queued follow-ups. |
+| Notifications | automatic | Sends `cmux notify` once Pi settles after retries, compaction, and queued follow-ups. Only fires while Pi runs interactively inside a cmux surface; silent in terminals outside cmux and in headless/embedded runs (SDK, `--print`, JSON, RPC). |
 | Sidebar status/log | automatic | Updates cmux status, progress, and logs while Pi runs, then flashes once Pi settles. |
 | Split Pi | `/cmv [prompt]`, `/cmh [prompt]` | Opens a new right/lower split with Pi in the same project. |
 | Run a tool | `/cmo <cmd>`, `/cmoh <cmd>`, `/cmt <cmd>` | Opens a split or tab and runs a shell command in the same project. |
@@ -74,6 +74,7 @@ Detailed command examples: [docs/usage.md](docs/usage.md).
 | Variable | Default | Purpose |
 |---|---:|---|
 | `PI_CMUX_NOTIFY_LEVEL` | `all` | `all`, `medium`, `low`, or `disabled`. |
+| `PI_CMUX_NOTIFY_FORCE` | `0` | Set `1` to notify even when Pi is not running inside a cmux surface. |
 | `PI_CMUX_NOTIFY_INCLUDE_RESPONSE` | `0` | Append truncated final assistant response to non-error notifications. |
 | `PI_CMUX_NOTIFY_THRESHOLD_MS` | `15000` | Duration threshold for `Task Complete` vs `Waiting`. |
 | `PI_CMUX_SIDEBAR` | `1` | Set `0` to disable sidebar integration. |

--- a/extensions/cmux-notify.ts
+++ b/extensions/cmux-notify.ts
@@ -1,4 +1,4 @@
-import type { AgentEndEvent, ExtensionAPI, ToolResultEvent } from "@earendil-works/pi-coding-agent";
+import type { AgentEndEvent, ExtensionAPI, ExtensionContext, ToolResultEvent } from "@earendil-works/pi-coding-agent";
 import {
 	isBashToolResult,
 	isEditToolResult,
@@ -55,6 +55,17 @@ function getNotifyLevelFromEnv(): NotifyLevel {
 		return value;
 	}
 	return DEFAULT_NOTIFY_LEVEL;
+}
+
+/**
+ * Only notify when this Pi instance actually runs inside a cmux surface.
+ * Headless/embedded runs (SDK, print, JSON, RPC) and plain terminals must stay
+ * silent even though the cmux app (and its socket) is reachable.
+ */
+function isRunningInsideCmux(ctx: ExtensionContext): boolean {
+	if (process.env.PI_CMUX_NOTIFY_FORCE === "1") return true;
+	if (ctx.mode !== "tui") return false;
+	return Boolean(process.env.CMUX_SURFACE_ID || process.env.CMUX_PANEL_ID);
 }
 
 function pluralize(count: number, singular: string, plural: string = `${singular}s`): string {
@@ -266,14 +277,16 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 		return { ok: true };
 	};
 
-	pi.on("agent_start", async () => {
+	pi.on("agent_start", async (_event, ctx) => {
+		if (!isRunningInsideCmux(ctx)) return;
 		if (logicalRunActive) return;
 		logicalRunActive = true;
 		pendingCompletionMessages = undefined;
 		runState = createEmptyRunState();
 	});
 
-	pi.on("tool_result", async (event) => {
+	pi.on("tool_result", async (event, ctx) => {
+		if (!isRunningInsideCmux(ctx)) return;
 		if (event.isError && !runState.firstToolError) {
 			runState.firstToolError = summarizeError(event);
 		}
@@ -305,11 +318,13 @@ export default function cmuxNotifyExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("agent_settled", async (_event, ctx) => {
+		if (!isRunningInsideCmux(ctx)) return;
 		if (!ctx.isIdle() || !pendingCompletionMessages) return;
 
 		const messages = pendingCompletionMessages;
 		pendingCompletionMessages = undefined;
 		logicalRunActive = false;
+
 
 		const durationMs = Date.now() - runState.startedAt;
 		const runError = summarizeRunError(messages, runState.firstToolError);

--- a/tests/cmux-lifecycle.test.mjs
+++ b/tests/cmux-lifecycle.test.mjs
@@ -31,8 +31,9 @@ function createHarness(extension) {
 	};
 }
 
-function createContext(idle = true) {
+function createContext(idle = true, mode = "tui") {
 	return {
+		mode,
 		isIdle: () => idle,
 		sessionManager: {
 			getBranch: () => [],
@@ -89,6 +90,7 @@ test("notifications wait for idle settlement and use the final low-level result"
 			PI_CMUX_NOTIFY_INCLUDE_RESPONSE: "1",
 			PI_CMUX_NOTIFY_LEVEL: "all",
 			PI_CMUX_NOTIFY_THRESHOLD_MS: "999999",
+			CMUX_SURFACE_ID: "test-surface",
 		},
 		async () => {
 			const harness = createHarness(cmuxNotifyExtension);
@@ -119,6 +121,56 @@ test("notifications wait for idle settlement and use the final low-level result"
 			]);
 
 			await harness.emit("agent_settled", { type: "agent_settled" });
+			assert.equal(cmuxCalls(harness.execCalls, "notify").length, 1);
+		},
+	);
+});
+
+test("notifications stay silent outside cmux surfaces", async () => {
+	await withEnvironment(
+		{
+			PI_CMUX_NOTIFY_DEBOUNCE_MS: "0",
+			PI_CMUX_NOTIFY_LEVEL: "all",
+			CMUX_SURFACE_ID: undefined,
+			CMUX_PANEL_ID: undefined,
+		},
+		async () => {
+			const harness = createHarness(cmuxNotifyExtension);
+			const succeeded = assistantMessage("stop", "Done");
+
+			// Headless/embedded modes (SDK, --print, JSON, RPC) stay silent.
+			for (const mode of ["print", "json", "rpc", "sdk"]) {
+				await harness.emit("agent_start", { type: "agent_start" }, createContext(true, mode));
+			await harness.emit("agent_end", { type: "agent_end", messages: [succeeded] });
+				await harness.emit("agent_settled", { type: "agent_settled" }, createContext(true, mode));
+				assert.equal(cmuxCalls(harness.execCalls, "notify").length, 0, `mode=${mode} should not notify`);
+			}
+
+			// Interactive TUI in a terminal outside cmux (no surface/panel env) stays silent too.
+			await harness.emit("agent_start", { type: "agent_start" }, createContext(true, "tui"));
+			await harness.emit("agent_end", { type: "agent_end", messages: [succeeded] });
+			await harness.emit("agent_settled", { type: "agent_settled" }, createContext(true, "tui"));
+			assert.equal(cmuxCalls(harness.execCalls, "notify").length, 0);
+		},
+	);
+});
+
+test("PI_CMUX_NOTIFY_FORCE restores notifications outside cmux surfaces", async () => {
+	await withEnvironment(
+		{
+			PI_CMUX_NOTIFY_DEBOUNCE_MS: "0",
+			PI_CMUX_NOTIFY_LEVEL: "all",
+			PI_CMUX_NOTIFY_FORCE: "1",
+			CMUX_SURFACE_ID: undefined,
+			CMUX_PANEL_ID: undefined,
+		},
+		async () => {
+			const harness = createHarness(cmuxNotifyExtension);
+			const succeeded = assistantMessage("stop", "Done");
+
+			await harness.emit("agent_start", { type: "agent_start" }, createContext(true, "print"));
+			await harness.emit("agent_end", { type: "agent_end", messages: [succeeded] });
+			await harness.emit("agent_settled", { type: "agent_settled" }, createContext(true, "print"));
 			assert.equal(cmuxCalls(harness.execCalls, "notify").length, 1);
 		},
 	);


### PR DESCRIPTION
## What

Notifications are now gated on Pi actually running interactively inside a cmux surface: `ctx.mode === "tui"` plus `CMUX_SURFACE_ID`/`CMUX_PANEL_ID` being set. Opt back in with `PI_CMUX_NOTIFY_FORCE=1`.

## Why

The cmux socket is reachable from anywhere on the machine, so the current behavior notifies through a running cmux app even when the Pi process is **not** the one driving a cmux surface:

- headless runs: scripts using `pi --print`, cron jobs, CI steps
- embedded runs: SDK, JSON, RPC modes
- interactive Pi in a plain terminal outside cmux

Every such run pops a "Task Complete" notification in the user's cmux app for work they never see in a tab.

## Implementation notes

A single `isRunningInsideCmux(ctx)` guard at the three notify entry points (`agent_start`, `tool_result`, `agent_settled`). `agent_end` only stages pending messages and is left ungated. The check is short-circuited by `PI_CMUX_NOTIFY_FORCE=1` for users who want the old behavior back.

Composes with the settlement refactor from #15 — the gate runs before the idle/settlement checks, so nothing else about the settlement flow changes.

## Testing

- New regression tests: headless modes (`print`/`json`/`rpc`/`sdk`) and tui-without-cmux stay silent; `PI_CMUX_NOTIFY_FORCE=1` restores notifications.
- Existing settlement test updated to run inside a simulated cmux surface (`CMUX_SURFACE_ID`).
- `npm test` 88/88 pass, `tsc --strict` typecheck clean.

## Docs

README workflow table + `PI_CMUX_NOTIFY_FORCE` env row, CHANGELOG `[Unreleased]` entry.